### PR TITLE
fix: pr image cleanup

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -2,7 +2,7 @@
 name: Build & Push
 
 on:
-  merge_queue:
+  merge_group:
   pull_request:
   push:
     tags: ["v*.*.*"]

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           file: .devcontainer/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: if: ${{ github.event_name != 'merge_group' }}
+          push: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           sbom: true

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -36,12 +36,10 @@ jobs:
           # When modifying please update the tags in the clean up workflow as well
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -2,6 +2,7 @@
 name: Build & Push
 
 on:
+  merge_queue:
   pull_request:
   push:
     tags: ["v*.*.*"]
@@ -28,6 +29,7 @@ jobs:
       id-token: write
     steps:
       - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
+        if: ${{ github.event_name != 'merge_group' }}
       - uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
         id: meta
         with:
@@ -43,6 +45,7 @@ jobs:
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -52,7 +55,7 @@ jobs:
         with:
           file: .devcontainer/Dockerfile
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: if: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           sbom: true
@@ -60,6 +63,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - name: Sign the published Docker image
+        if: ${{ github.event_name != 'merge_group' }}
         env:
           COSIGN_EXPERIMENTAL: "true"
         # This step uses the identity token to provision an ephemeral certificate

--- a/.github/workflows/cleanup-pr-image.yml
+++ b/.github/workflows/cleanup-pr-image.yml
@@ -7,41 +7,25 @@ on:
 permissions:
   contents: read
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
-  generate-tag-matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      tags: ${{ steps.matrix.outputs.tags }}
-    steps:
-      - uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
-        id: meta
-        with:
-          images: ${{ env.REGISTRY }}/${{ github.repository }}
-          # Generate Docker tags based on the following events/attributes
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha
-      - run: |
-          TAGS="$(echo "${{ steps.meta.outputs.tags }}" | jq -c --raw-input 'split(",")')"
-          echo "tags=${TAGS}" >> "${GITHUB_OUTPUT}"
-        id: matrix
   delete-images:
     runs-on: ubuntu-latest
     permissions:
       packages: write
-    needs: generate-tag-matrix
-    strategy:
-      matrix:
-        tag: ${{ fromJSON(needs.generate-tag-matrix.outputs.tags) }}
     steps:
+      - uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
+      - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - run: cosign clean -f "${{ env.REGISTRY }}/${{ github.repository }}:pr-${{ github.event.pull_request.number }}"
       - uses: bots-house/ghcr-delete-image-action@3827559c68cb4dcdf54d813ea9853be6d468d3a4 # v1.1.0
         with:
           owner: ${{ github.repository_owner }}
           name: ${{ github.event.repository.name }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ matrix.tag }}
+          tag: pr-${{ github.event.pull_request.number }}


### PR DESCRIPTION
Don't tag images by short sha. In case of a PR only use the PR number to tag the image. In addition clean-up cosign signatures before deleting the PR image on PR close event.