### PR TITLE
ci: prime GitHub cache with Docker images built on main

### DIFF
--- a/.github/workflows/prime-cache.yml
+++ b/.github/workflows/prime-cache.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
         with:
-        with:
           file: .devcontainer/Dockerfile
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha

--- a/.github/workflows/prime-cache.yml
+++ b/.github/workflows/prime-cache.yml
@@ -1,0 +1,27 @@
+---
+name: Prime Cache
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+
+jobs:
+  prime-docker-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+      - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+      - uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+        with:
+          file: .devcontainer/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
GitHub cache can re-use cached data from ancestor branches. This PR adds a Docker build for all supported platforms on main that primes the cache. This should speed-up builds on feature branches and on the merge queue.