### PR TITLE
chore: add annotations to manifest

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -69,7 +69,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
       - uses: anchore/sbom-action@78fc58e266e87a38d4194b2137a3d4e9bcaf7ca1 # v0.14.3
-        if: ${{ steps.build-and-push.outputs.digest != '' }}
+        if: ${{ steps.build-and-push.outputs.digest != '' && github.event_name != 'merge_group' }}
         with:
           image: ${{ env.REGISTRY }}/${{ github.repository }}@${{ steps.build-and-push.outputs.digest }}
           dependency-snapshot: true

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -43,7 +43,8 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - run: |
-          ANNOTATIONS=echo $DOCKER_METADATA_OUTPUT_LABELS | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ','
+          set -Eeuo pipefail
+          ANNOTATIONS=echo '$DOCKER_METADATA_OUTPUT_LABELS' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ','
           echo annotations=$ANNOTATIONS >> "$GITHUB_OUTPUT"
         id: annotations
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -45,7 +45,7 @@ jobs:
       - run: |
           set -Eeuo pipefail
           ANNOTATIONS=$(echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ',')
-          echo annotations=${ANNOTATIONS::-1} >> "$GITHUB_OUTPUT"
+          echo "annotations=${ANNOTATIONS::-1}" >> "$GITHUB_OUTPUT"
         id: annotations
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
@@ -63,7 +63,7 @@ jobs:
           push: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: ${{ steps.annotations.outputs.annotations }}type=image,name=target
+          outputs: type=image,name=target,${{ steps.annotations.outputs.annotations }}
           sbom: true
           provenance: true
           cache-from: type=gha

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -63,7 +63,7 @@ jobs:
           push: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,${{ steps.annotations.outputs.annotations }}
+          outputs: type=image,${{ steps.annotations.outputs.annotations }}
           sbom: true
           provenance: true
           cache-from: type=gha

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -44,8 +44,8 @@ jobs:
             type=semver,pattern={{major}}
       - run: |
           set -Eeuo pipefail
-          ANNOTATIONS=echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ','
-          echo annotations=$ANNOTATIONS >> "$GITHUB_OUTPUT"
+          ANNOTATIONS=$(echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ',')
+          echo annotations=${ANNOTATIONS::-1} >> "$GITHUB_OUTPUT"
         id: annotations
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,7 +42,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-      - run: echo 'annotations=$(echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ',') >> "$GITHUB_OUTPUT"
+      - run: |
+          ANNOTATIONS=echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ','
+          echo annotations=$ANNOTATIONS >> "$GITHUB_OUTPUT"
         id: annotations
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -43,7 +43,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
       - run: |
-          ANNOTATIONS=echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ','
+          ANNOTATIONS=echo $DOCKER_METADATA_OUTPUT_LABELS | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ','
           echo annotations=$ANNOTATIONS >> "$GITHUB_OUTPUT"
         id: annotations
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
@@ -62,7 +62,7 @@ jobs:
           push: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,${{ steps.annotations.outputs.annotations }}
+          outputs: ${{ steps.annotations.outputs.annotations }}type=image,name=target
           sbom: true
           provenance: true
           cache-from: type=gha

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -44,7 +44,7 @@ jobs:
             type=semver,pattern={{major}}
       - run: |
           set -Eeuo pipefail
-          ANNOTATIONS=echo '$DOCKER_METADATA_OUTPUT_LABELS' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ','
+          ANNOTATIONS=echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ','
           echo annotations=$ANNOTATIONS >> "$GITHUB_OUTPUT"
         id: annotations
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -58,6 +58,7 @@ jobs:
           push: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=target,annotations-index.org.opencontainers.image.source=https://github.com/philips-software/amp-devcontainer
           sbom: true
           provenance: true
           cache-from: type=gha

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,6 +42,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
+      - run: echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ',' >> "$GITHUB_OUTPUT"
+        id: annotations
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
       - uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
@@ -58,7 +60,7 @@ jobs:
           push: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotation-index.org.opencontainers.image.source=https://github.com/philips-software/amp-devcontainer,annotation-index.org.opencontainers.image.description=amp-devcontainer is a fully loaded devcontainer useable for (embedded) C++ development
+          outputs: type=image,name=target,${{ steps.annotations.outputs }}
           sbom: true
           provenance: true
           cache-from: type=gha

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -42,7 +42,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-      - run: echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ',' >> "$GITHUB_OUTPUT"
+      - run: echo 'annotations=$(echo '${{ steps.meta.outputs.labels }}' | sed 's/org.opencontainers.image./annotation-index.org.opencontainers.image./' | tr '\n' ',') >> "$GITHUB_OUTPUT"
         id: annotations
       - uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
       - uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
@@ -60,7 +60,7 @@ jobs:
           push: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,${{ steps.annotations.outputs }}
+          outputs: type=image,name=target,${{ steps.annotations.outputs.annotations }}
           sbom: true
           provenance: true
           cache-from: type=gha

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -58,7 +58,7 @@ jobs:
           push: ${{ github.event_name != 'merge_group' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=image,name=target,annotations-index.org.opencontainers.image.source=https://github.com/philips-software/amp-devcontainer
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.source=https://github.com/philips-software/amp-devcontainer,annotation-index.org.opencontainers.image.description=amp-devcontainer is a fully loaded devcontainer useable for (embedded) C++ development
           sbom: true
           provenance: true
           cache-from: type=gha


### PR DESCRIPTION
Add annotations to the manifest file as-per https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#adding-a-description-to-multi-arch-images.

Adding annotations has several benefits:
- Dependabot can show more information on changes when updating dependencies https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#docker
- The packages overview has more detail

Adding annotations can be simplified when https://github.com/docker/build-push-action/pull/992 is merged.