### PR TITLE
fix: make sure all dependency updates are releasable units

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,12 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: "feat"
+      prefix: "deps(docker)"
       include: "scope"
   - package-ecosystem: pip
     directory: .devcontainer
     schedule:
       interval: daily
     commit-message:
-      prefix: "feat"
+      prefix: "deps"
       include: "scope"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -25,8 +25,8 @@ jobs:
         run: ./update-dependencies.sh apt-requirements-base.json apt-requirements-clang.json
       - uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
-          commit-message: "chore(deps): update apt dependencies"
+          commit-message: "deps(apt): update dependencies"
           branch: feature/update-apt-dependencies
-          title: "chore(deps): update apt dependencies"
+          title: "deps(apt): update dependencies"
           labels: dependencies
           token: ${{ secrets.AMP_RELEASER_TOKEN }}


### PR DESCRIPTION
Using the `deps` tag will trigger release-please on the main branch as per release-please documentation (https://github.com/googleapis/release-please#step-1-ensure-releasable-units-are-merged).