### PR TITLE
ci: dependency updates end up in CHANGELOG.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,12 +11,10 @@ updates:
     schedule:
       interval: daily
     commit-message:
-      prefix: "deps(docker)"
-      include: "scope"
+      prefix: "feat(deps)"
   - package-ecosystem: pip
     directory: .devcontainer
     schedule:
       interval: daily
     commit-message:
-      prefix: "deps"
-      include: "scope"
+      prefix: "feat(deps)"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -25,8 +25,8 @@ jobs:
         run: ./update-dependencies.sh apt-requirements-base.json apt-requirements-clang.json
       - uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
         with:
-          commit-message: "deps(apt): update dependencies"
+          commit-message: "feat(deps): update dependencies"
           branch: feature/update-apt-dependencies
-          title: "deps(apt): update dependencies"
+          title: "feat(deps): update dependencies"
           labels: dependencies
           token: ${{ secrets.AMP_RELEASER_TOKEN }}


### PR DESCRIPTION
Additionally remove the "scope" option, see: https://github.com/dependabot/dependabot-core/issues/8443