### PR TITLE
feat: remove unused package bzip2

### DIFF
--- a/.devcontainer/apt-requirements-base.json
+++ b/.devcontainer/apt-requirements-base.json
@@ -1,5 +1,4 @@
 {
-  "bzip2": "1.0.8-5build1",
   "ca-certificates": "20230311ubuntu0.22.04.1",
   "g++-12": "12.3.0-1ubuntu1~22.04",
   "gdb-multiarch": "12.1-0ubuntu1~22.04",


### PR DESCRIPTION
bzip2 was used to extract the previous arm toolchain. The arm toolchain is now packed with xz.