### PR TITLE
ci(dependabot): group minor and patch updates for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      minor-and-patch-action-updates:
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: docker
     directory: .devcontainer
     schedule:


### PR DESCRIPTION
Group together all minor and patch level updates of actions.

One PR will be created for all actions that need update when the semver level is minor or patch. All major updates will still get their own PR as they will more likely break or introduce new functionality.