### PR TITLE
feat: set CMAKE_EXPORT_COMPILE_COMMANDS to On

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -31,8 +31,9 @@ COPY .devcontainer/requirements.txt /tmp/requirements.txt
 RUN python3 -m pip install --require-hashes --no-cache-dir -r /tmp/requirements.txt \
  && rm -rf /tmp/requirements.txt
 
-# Set default generator for CMake to Ninja
+# Set default environment options for CMake
 ENV CMAKE_GENERATOR="Ninja"
+ENV CMAKE_EXPORT_COMPILE_COMMANDS="On"
 
 # Install clang toolchain
 COPY .devcontainer/apt-requirements-clang.json /tmp/apt-requirements-clang.json
@@ -84,7 +85,8 @@ RUN batstmp="$(mktemp -d /tmp/bats-core-${BATS_VERSION}.XXXX)" \
  && bash "${batstmp}/bats-core-${BATS_VERSION}/install.sh" /usr/local \
  && rm -rf "${batstmp}" \
  && git -C /usr/local clone -b v0.3.0 https://github.com/bats-core/bats-support.git \
- && git -C /usr/local clone -b v2.1.0 https://github.com/bats-core/bats-assert.git
+ && git -C /usr/local clone -b v2.1.0 https://github.com/bats-core/bats-assert.git \
+ && git -C /usr/local clone -b v0.4.0 https://github.com/bats-core/bats-file
 
 # Install xwin
 RUN wget -qO - "https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VERSION}/xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz" | tar -xzv -C /usr/local/bin --strip-components=1 "xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl/xwin"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -85,8 +85,7 @@ RUN batstmp="$(mktemp -d /tmp/bats-core-${BATS_VERSION}.XXXX)" \
  && bash "${batstmp}/bats-core-${BATS_VERSION}/install.sh" /usr/local \
  && rm -rf "${batstmp}" \
  && git -C /usr/local clone -b v0.3.0 https://github.com/bats-core/bats-support.git \
- && git -C /usr/local clone -b v2.1.0 https://github.com/bats-core/bats-assert.git \
- && git -C /usr/local clone -b v0.4.0 https://github.com/bats-core/bats-file
+ && git -C /usr/local clone -b v2.1.0 https://github.com/bats-core/bats-assert.git
 
 # Install xwin
 RUN wget -qO - "https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VERSION}/xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz" | tar -xzv -C /usr/local/bin --strip-components=1 "xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl/xwin"

--- a/test/testsuite.bats
+++ b/test/testsuite.bats
@@ -26,6 +26,7 @@ teardown_file() {
 setup() {
   load '/usr/local/bats-support/load'
   load '/usr/local/bats-assert/load'
+  load '/usr/local/bats-file/load'
 }
 
 teardown() {
@@ -65,6 +66,15 @@ teardown() {
 
   run cmake --build --preset clang-cl
   assert_success
+}
+
+# bats test_tags=tc:20
+@test "compilation database should be generated on CMake configure" {
+  run cmake --preset gcc
+  assert_file_exists build/gcc/compile_commands.json
+
+  run cmake --preset gcc-arm-none-eabi
+  assert_file_exists build/gcc-arm-none-eabi/compile_commands.json
 }
 
 # bats test_tags=tc:4

--- a/test/testsuite.bats
+++ b/test/testsuite.bats
@@ -26,7 +26,6 @@ teardown_file() {
 setup() {
   load '/usr/local/bats-support/load'
   load '/usr/local/bats-assert/load'
-  load '/usr/local/bats-file/load'
 }
 
 teardown() {
@@ -71,10 +70,10 @@ teardown() {
 # bats test_tags=tc:20
 @test "compilation database should be generated on CMake configure" {
   run cmake --preset gcc
-  assert_file_exists build/gcc/compile_commands.json
+  [ -e build/gcc/compile_commands.json ]
 
   run cmake --preset gcc-arm-none-eabi
-  assert_file_exists build/gcc-arm-none-eabi/compile_commands.json
+  [ -e build/gcc-arm-none-eabi/compile_commands.json ]
 }
 
 # bats test_tags=tc:4


### PR DESCRIPTION
This PR enables default generation of a compilation database (compile_commands.json) that can be used by tools like clangd, clang-tidy and include-what-you-use to provide diagnostics.