### PR TITLE
fix: move customizations.vscode.settings to the correct level

### DIFF
--- a/.devcontainer/devcontainer-metadata-vscode.json
+++ b/.devcontainer/devcontainer-metadata-vscode.json
@@ -13,20 +13,20 @@
           "ms-vsliveshare.vsliveshare@1.0.5905",
           "SonarSource.sonarlint-vscode@4.3.0",
           "xaver.clang-format@1.9.0"
-        ]
-      },
-      "settings": {
-        "C_Cpp.intelliSenseEngine": "disabled",
-        "C_Cpp.formatting": "clangFormat",
-        "clangd.arguments": [
-          "--query-driver=/opt/**/arm-none-eabi-*",
-          "--compile-commands-dir=${userHome}/.amp"
         ],
-        "cmake.copyCompileCommands": "${userHome}/.amp/compile_commands.json",
-        "cmake.options.statusBarVisibility": "compact",
-        "cortex-debug.gdbPath": "gdb-multiarch",
-        "cortex-debug.objdumpPath": "arm-none-eabi-objdump",
-        "sonarlint.pathToCompileCommands": "${userHome}/.amp/compile_commands.json"
+        "settings": {
+          "C_Cpp.intelliSenseEngine": "disabled",
+          "C_Cpp.formatting": "clangFormat",
+          "clangd.arguments": [
+            "--query-driver=/opt/**/arm-none-eabi-*",
+            "--compile-commands-dir=${userHome}/.amp"
+          ],
+          "cmake.copyCompileCommands": "${userHome}/.amp/compile_commands.json",
+          "cmake.options.statusBarVisibility": "compact",
+          "cortex-debug.gdbPath": "gdb-multiarch",
+          "cortex-debug.objdumpPath": "arm-none-eabi-objdump",
+          "sonarlint.pathToCompileCommands": "/root/.amp/compile_commands.json"
+        }
       }
     }
   }


### PR DESCRIPTION
# Pull Request

## Description of changes

The JSON property customizations.vscode.settings was rooted under customizations instead of under customizations.vscode. This PR fixes that mistake.

Fixes #317

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the contribution guidelines for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
