### PR TITLE
chore(deps): update matepek.vscode-catch2-test-adapter, ms-vscode.cmake-tools, ms-vscode.cpptools, ms-vsliveshare.vsliveshare

### DIFF
--- a/.devcontainer/devcontainer-metadata-vscode.json
+++ b/.devcontainer/devcontainer-metadata-vscode.json
@@ -8,11 +8,11 @@
         "extensions": [
           "llvm-vs-code-extensions.vscode-clangd@0.1.26",
           "marus25.cortex-debug@1.12.1",
-          "matepek.vscode-catch2-test-adapter@4.8.3",
+          "matepek.vscode-catch2-test-adapter@4.11.0",
           "mhutchie.git-graph@1.30.0",
-          "ms-vscode.cmake-tools@1.17.15",
-          "ms-vscode.cpptools@1.18.5",
-          "ms-vsliveshare.vsliveshare@1.0.5905",
+          "ms-vscode.cmake-tools@1.17.17",
+          "ms-vscode.cpptools@1.19.7",
+          "ms-vsliveshare.vsliveshare@1.0.5918",
           "SonarSource.sonarlint-vscode@4.3.0",
           "xaver.clang-format@1.9.0"
         ],


### PR DESCRIPTION
Updates `ms-vsliveshare.vsliveshare` from 1.0.5905 to 1.0.5918
<details>
<summary>Release notes</summary>
<blockquote>


</blockquote>
</details>

Updates `ms-vscode.cpptools` from 1.18.5 to 1.19.7
<details>
<summary>Release notes</summary>
<blockquote>

## Instructions
Install it via using the Extensions view in VS Code or download a vsix that matches your OS from Assets section below (or the "Download" dropdown in the "Version History" tab section on the [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) website) and then use the `Extensions: Install from VSIX...` command in VS Code (don't double-click the vsix or another app like VS might try to open it incorrectly).

## Requirements
* VS Code 1.67.0 or later.

## Changes
### Enhancement
* Performance improvement.

## Instructions
Install it via using the Extensions view in VS Code or download a vsix that matches your OS from Assets section below (or the "Download" dropdown in the "Version History" tab section on the [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) website) and then use the `Extensions: Install from VSIX...` command in VS Code (don't double-click the vsix or another app like VS might try to open it incorrectly).

## Requirements
* VS Code 1.67.0 or later.

## Changes
### Enhancements
* Change how `args` and `command` fields are handled in `cppbuild` tasks, to match the behavior of VS Code `shell` build tasks, including explicit `quoting` support. [#12001](https://github.com/microsoft/vscode-cpptools/issues/12001)
* Enable C23 IntelliSense support, and add support for `clatest` `std` value for MSVC. [#12020](https://github.com/microsoft/vscode-cpptools/issues/12020)

### Bug Fixes
* Fix the IntelliSense cache not being pruned. [#11925](https://github.com/microsoft/vscode-cpptools/issues/11925)
* Fix an issue with duplicate `Add #include` code actions appearing if the same header name exists in multiple locations. [#11989](https://github.com/microsoft/vscode-cpptools/issues/11989)
* Fix compiler querying with a `-index-store-path` argument. [#12012](https://github.com/microsoft/vscode-cpptools/issues/12012)
* Fix an issue with changes to `C_Cpp.inlayHints` settings not taking effect immediately. [#12013](https://github.com/microsoft/vscode-cpptools/issues/12013)
* Fix an issue with how Doxygen `brief` and `param` are displayed on hover. [#12015](https://github.com/microsoft/vscode-cpptools/issues/12015)
* Fix an issue preventing the extension from functioning if installed via snap on Linux. [#12021](https://github.com/microsoft/vscode-cpptools/issues/12021)
* Fix compiler querying with a `-Xclang -mllvm` argument. [#12024](https://github.com/microsoft/vscode-cpptools/issues/12024)
* Fix the include graph lookup not occurring for source files. [#12036](https://github.com/microsoft/vscode-cpptools/issues/12036)
* Fix exclusions not applying to dependent headers with recursive includes. [#12042](https://github.com/microsoft/vscode-cpptools/issues/12042)
* Fix a potential cpptools process hang on shutdown.

## Instructions
Install it via using the Extensions view in VS Code or download a vsix that matches your OS from Assets section below (or the "Download" dropdown in the "Version History" tab section on the [Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) website) and then use the `Extensions: Install from VSIX...` command in VS Code (don't double-click the vsix or another app like VS might try to open it incorrectly).

## Requirements
* VS Code 1.67.0 or later.

## Changes
### Enhancements
 * Enable support for fuzzy symbol searches. [#2751](https://github.com/microsoft/vscode-cpptools/issues/2751)
   * This may not be enabled for all users unless `C_Cpp.experimentalFeatures` is `enabled`.
* Implement progressive population of IntelliSense results. [#7759](https://github.com/microsoft/vscode-cpptools/issues/7759)
 * Improve performance of symbol searches. [#7908](https://github.com/microsoft/vscode-cpptools/issues/7908), [#7914](https://github.com/microsoft/vscode-cpptools/issues/7914), [#11557](https://github.com/microsoft/vscode-cpptools/issues/11557)
   * This may not be enabled for all users unless `C_Cpp.experimentalFeatures` is `enabled`.
* Support insert mode for auto-complete. [#10613](https://github.com/microsoft/vscode-cpptools/issues/10613)
  * Use the `"[cpp]": { "editor.suggest.insertMode": "insert" } ` and `"[c]": { "editor.suggest.insertMode": "insert" } ` settings to override the extension's defaults.
* Improve memory efficiency by using token parsing in the 'Add #include' feature. [#11515](https://github.com/microsoft/vscode-cpptools/issues/11515)
* Change the default setting value for `C_Cpp.intelliSenseUpdateDelay` from 2s to 1s. [PR #11932](https://github.com/microsoft/vscode-cpptools/pull/11932)
* Improve the types supported for the 'Add #include' code action.
* Various performance improvements.

### Bug Fixes
* Fix IntelliSense bug with type deduction using concepts. [#8132](https://github.com/microsoft/vscode-cpptools/issues/8132)
* Fix clang-format error messages not being logged. [#8944](https://github.com/microsoft/vscode-cpptools/issues/8944)
* Fix indentation missing in markdown fenced code blocks. [#11379](https://github.com/microsoft/vscode-cpptools/issues/11379)
* Fix shell escaping for `cppbuild` task command line arguments. [#11422](https://github.com/microsoft/vscode-cpptools/issues/11422)
* Fix IntelliSense not updating when a `#include` is added from a refactor command. [#11549](https://github.com/microsoft/vscode-cpptools/issues/11549)
* Fix 'Add '#include' code actions for Mac frameworks. [#11579](https://github.com/microsoft/vscode-cpptools/issues/11579)
* Fix the parent path of the source file in `compile_commands.json` not being added to the browse.path. [#11631](https://github.com/microsoft/vscode-cpptools/issues/11631)
* Fix the database not getting updated in certain cases when switching configurations. [#11649](https://github.com/microsoft/vscode-cpptools/issues/11649)
* Fix a cpptools crash with certain projects. [#11674](https://github.com/microsoft/vscode-cpptools/issues/11674)
* Fix snippet and include completion. [#11715](https://github.com/microsoft/vscode-cpptools/issues/11715), [#11720](https://github.com/microsoft/vscode-cpptools/issues/11720)
* Fix formatting not working in headers after using 'Extract to Function'. [#11729](https://github.com/microsoft/vscode-cpptools/issues/11729)
* Fix document symbol requests not checking for cancellation. [#11750](https://github.com/microsoft/vscode-cpptools/issues/11750)
* Fix the default `editor.wordBasedSuggestions` setting for VS Code versions 1.85 or newer. [PR #11773](https://github.com/microsoft/vscode-cpptools/pull/11773)
  * This change doesn't work with VS Code versions 1.84 or older, due to [Microsoft/vscode#200685](https://github.com/microsoft/vscode/issues/200685)
* Fix code analysis results getting cleared after there's a configuration update. [#11790](https://github.com/microsoft/vscode-cpptools/issues/11790)
* Fix an exception getting thrown if IntelliSense is disabled but a configuration provider is registered. [#11795](https://github.com/microsoft/vscode-cpptools/issues/11795)
* Fix an EACCES error when using include wildcards with system includes. [#11833](https://github.com/microsoft/vscode-cpptools/issues/11833)
* Fix German code analysis translations. [PR #11845](https://github.com/microsoft/vscode-cpptools/pull/11845)
  * Thank you for the contribution. [@Sir2B (Tobias Obermayer)](https://github.com/Sir2B)
* Trim trailing spaces from include paths in the configuration UI. [#11862](https://github.com/microsoft/vscode-cpptools/issues/11862)
* Fix comma delimited lists in `@param` Doxygen parameters. [#11868](https://github.com/microsoft/vscode-cpptools/issues/11868)
* Fix incorrect errors for `compilerPath` in the configuration UI for compilers that can be found in PATH. [#11903](https://github.com/microsoft/vscode-cpptools/issues/11903)
* Fix an issue with include sorting when formatting with clang-format. [#11914](https://github.com/microsoft/vscode-cpptools/issues/11914)
* Fix the `-include` arg of `-Xarg_<arg1>` getting filtered out, leading to a failed compiler query. [#11965](https://github.com/microsoft/vscode-cpptools/issues/11965)
* Fix the `-arch` flag overwriting the `-target` flag's value when it shouldn't. [#11971](https://github.com/microsoft/vscode-cpptools/issues/11971)
* Fix an issue in which the directory specified in a `compile_commands.json` was not being used as the current directory when querying the specified compiler path.
* Fix an issue with configuring IntelliSense for a header file after having chosen an associated source file in which inclusion of the header is disabled or removed.
* Fix an issue where use of an explicit `compilerPath` to override the compiler in a `compile_commands.json` will also throw out the compiler arguments.
* Fix IntelliSense passes occurring while a user is still typing, instead of honoring the `C_Cpp.intelliSenseUpdateDelay` setting.
* Fix issues related to support for C++ modules and parsing of related compiler arguments.
* Fix issues with the tag parsing status sometimes not being accurately reflected in the UI.
* Fix document and workspace symbol requests being blocked by an IntelliSense request.
* Remove the requirement that a file be open in the editor from various LSP requests.
* Fix a crash if `compile_commands.json` doesn't have an array at the root.
* Fix a call hierarchy bug leading to use of header-only TU's unnecessarily.
* Fix an issue that could result in the Outline pane not being populated.
* Fix a bug that could lead to missing TU source file candidates.
* Address multiple issues with compiler querying of clang-cl.
* Fix a potential crash when using 'Find All References'.
* Fix a "random" IntelliSense crash during completion.
* Fix a crash if access to `/dev/urandom` is restricted.
* Fix some crashes reported by crash telemetry.
* Lots of other minor fixes.
</blockquote>
</details>

Updates `ms-vscode.cmake-tools` from 1.17.15 to 1.17.17
<details>
<summary>Release notes</summary>
<blockquote>

## 1.17.17

Bug Fixes:

- Fix the regression for inheritance of cache variables and other inheritable fields. [#3603](https://github.com/microsoft/vscode-cmake-tools/issues/3603)

## 1.17.16

Bug Fixes:

- Fix an issue where we weren't able to run tests when not using Presets. [#3589](https://github.com/microsoft/vscode-cmake-tools/issues/3589)
- Fix the order of preference for CMake Presets `inherit` field. [#3594](https://github.com/microsoft/vscode-cmake-tools/issues/3594)
</blockquote>
</details>

Updates `matepek.vscode-catch2-test-adapter` from 4.8.3 to 4.11.0
<details>
<summary>Release notes</summary>
<blockquote>

See [CHANGELOG.md](CHANGELOG.md) for details.

See [CHANGELOG.md](CHANGELOG.md) for details.

See [CHANGELOG.md](CHANGELOG.md) for details.
</blockquote>
</details>

> [!NOTE]
> Before merging this PR, please conduct a manual test checking basic functionality of the updated plug-ins. There are no automated tests for the VS Code Extension updates.