### PR TITLE
ci: use app-token-action for release and dependency updates

### DIFF
--- a/.github/workflows/linting-formatting.yml
+++ b/.github/workflows/linting-formatting.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: oxsecurity/megalinter/flavors/documentation@a7a0163b6c8ff7474a283d99a706e27483ddd80f # v7.10.0
         env:
           APPLY_FIXES: all

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,12 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
+      - uses: philips-software/app-token-action@9f5d57062c9f2beaffafaa9a34f66f824ead63a9 # v2.0.0
+        id: token
+        with:
+          app_id: ${{ secrets.FOREST_RELEASER_APP_ID }}
+          app_base64_private_key: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY_BASE64 }}
+          auth_type: installation
       - uses: google-github-actions/release-please-action@a37ac6e4f6449ce8b3f7607e4d97d0146028dc0b # v4.1.0
         with:
-          token: ${{ secrets.AMP_RELEASER_TOKEN }}
+          token: ${{ steps.token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,9 +15,6 @@ concurrency:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: philips-software/app-token-action@9f5d57062c9f2beaffafaa9a34f66f824ead63a9 # v2.0.0
         id: token

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,9 @@ concurrency:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: philips-software/app-token-action@9f5d57062c9f2beaffafaa9a34f66f824ead63a9 # v2.0.0
         id: token

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -20,15 +20,23 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - run: ./update-apt-dependencies.sh apt-requirements-base.json apt-requirements-clang.json
         working-directory: .devcontainer
+      - uses: philips-software/app-token-action@9f5d57062c9f2beaffafaa9a34f66f824ead63a9 # v2.0.0
+        id: token
+        with:
+          app_id: ${{ secrets.FOREST_RELEASER_APP_ID }}
+          app_base64_private_key: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY_BASE64 }}
+          auth_type: installation
       - uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # v6.0.1
         with:
           commit-message: "chore(deps): update dependencies"
           branch: feature/update-apt-dependencies
           title: "chore(deps): update dependencies"
           labels: dependencies,apt
-          token: ${{ secrets.AMP_RELEASER_TOKEN }}
+          token: ${{ steps.token.outputs.token }}
   update-vscode-extensions:
     runs-on: ubuntu-latest
     permissions:
@@ -36,10 +44,18 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/update-vscode-extensions
         id: update-extensions
         with:
           input-file: .devcontainer/devcontainer-metadata-vscode.json
+      - uses: philips-software/app-token-action@9f5d57062c9f2beaffafaa9a34f66f824ead63a9 # v2.0.0
+        id: token
+        with:
+          app_id: ${{ secrets.FOREST_RELEASER_APP_ID }}
+          app_base64_private_key: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY_BASE64 }}
+          auth_type: installation
       - uses: peter-evans/create-pull-request@a4f52f8033a6168103c2538976c07b467e8163bc # v6.0.1
         with:
           commit-message: "chore(deps): update ${{ join(fromJson(steps.update-extensions.outputs.updated-dependencies), ', ') }}"
@@ -51,4 +67,4 @@ jobs:
             > Before merging this PR, please conduct a manual test checking basic functionality of the updated plug-ins. There are no automated tests for the VS Code Extension updates.
           title: "chore(deps): update ${{ join(fromJson(steps.update-extensions.outputs.updated-dependencies), ', ') }}"
           labels: dependencies,vscode-extensions
-          token: ${{ secrets.AMP_RELEASER_TOKEN }}
+          token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
# Pull Request

## Description of changes

This PR switches from using a PAT (personal access token) to a token that is derived from an Org. wide app.

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the contribution guidelines for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
