### PR TITLE
chore: rework rust installation

### DIFF
--- a/.devcontainer/cpp/test/testsuite.bats
+++ b/.devcontainer/cpp/test/testsuite.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup_file() {
   # Installing the Windows SDK/CRT takes a long time.
   # When still valid, use the installation from cache.

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -23,6 +23,8 @@ RUN wget -qO /usr/local/share/ca-certificates/Cisco_Umbrella_Root_CA.crt https:/
  && update-ca-certificates
 
 # Install rust
+ENV CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:"$PATH"
 RUN rustup set profile minimal \
  && rustup default ${RUST_VERSION} \
  && rustup component add clippy llvm-tools rustfmt \
@@ -41,4 +43,6 @@ RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-13 20
 
 # Install additional rust tools
 RUN wget -qO - "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz" | tar xz -C "/usr/bin" \
- && cargo-binstall -y --locked cargo-binutils@0.3.6 cargo-mutants@24.5.0 flip-link@0.1.8 probe-rs-tools@0.24.0
+ && cargo-binstall -y --locked cargo-binutils@0.3.6 cargo-mutants@24.5.0 flip-link@0.1.8 \
+ # cargo-binstall can't (yet) install probe-rs-tools for aarch64, fall-back to script installation
+ && wget -qO - https://github.com/probe-rs/probe-rs/releases/download/v0.24.0/probe-rs-tools-installer.sh | sh

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -1,8 +1,8 @@
 FROM ubuntu:24.04@sha256:3f85b7caad41a95462cf5b787d8a04604c8262cdcdf9a472b8c52ef83375fe15
 
 ARG BATS_VERSION=1.10.0
+ARG CARGO_BINSTALL_VERSION=1.6.8
 ARG RUST_VERSION=1.78.0
-ARG RUSTUP_INIT_VERSION=1.26.0
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -23,17 +23,10 @@ RUN wget -qO /usr/local/share/ca-certificates/Cisco_Umbrella_Root_CA.crt https:/
  && update-ca-certificates
 
 # Install rust
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:"$PATH"
-RUN declare -A RUSTUP_SHA \
- RUSTUP_SHA["x86_64"]="0b2f6c8f85a3d02fde2efc0ced4657869d73fccfce59defb4e8d29233116e6db" \
- RUSTUP_SHA["aarch64"]="673e336c81c65e6b16dcdede33f4cc9ed0f08bde1dbe7a935f113605292dc800" \
- && wget -qO /tmp/rustup-init "https://static.rust-lang.org/rustup/archive/${RUSTUP_INIT_VERSION}/$(uname -m)-unknown-linux-gnu/rustup-init" \
- && echo "${RUSTUP_SHA[$(uname -m)]} /tmp/rustup-init" | sha256sum -c - \
- && chmod +x /tmp/rustup-init \
- && /tmp/rustup-init -y --no-modify-path --default-toolchain=${RUST_VERSION} --component llvm-tools --target thumbv7em-none-eabi \
- && rm -rf /tmp/rustup-init
+RUN rustup set profile minimal \
+ && rustup default ${RUST_VERSION} \
+ && rustup component add clippy llvm-tools rustfmt \
+ && rustup target add thumbv7em-none-eabi
 
 # Install bats
 RUN batstmp="$(mktemp -d /tmp/bats-core-${BATS_VERSION}.XXXX)" \
@@ -46,15 +39,6 @@ RUN batstmp="$(mktemp -d /tmp/bats-core-${BATS_VERSION}.XXXX)" \
 # Update all tool alternatives to the correct version
 RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-13 20
 
-# hadolint ignore=DL3008
-RUN apt-get update \
- && apt-get install -y --no-install-recommends libudev-dev \
- && cargo install cargo-binutils \
- && cargo install cargo-mutants \
- && cargo install flip-link \
- && cargo install probe-rs --features cli \
- && rm -rf "$CARGO_HOME/registry" \
- && apt-get purge -y libudev-dev \
- && apt-get autoremove -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+# Install additional rust tools
+RUN wget -qO - "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz" | tar xz -C "/usr/bin" \
+ && cargo-binstall -y --locked cargo-binutils@0.3.6 cargo-mutants@24.5.0 flip-link@0.1.8 probe-rs-tools@0.24.0

--- a/.devcontainer/rust/apt-requirements-base.json
+++ b/.devcontainer/rust/apt-requirements-base.json
@@ -4,6 +4,6 @@
   "git": "1:2.43.0-1ubuntu7",
   "gnupg2": "2.4.4-2ubuntu17",
   "libc6-dev": "2.39-0ubuntu8.1",
-  "pkg-config": "1.8.1-2build1",
+  "rustup": "1.26.0-5build1",
   "wget": "1.21.4-1ubuntu4"
 }

--- a/.devcontainer/rust/apt-requirements-base.json
+++ b/.devcontainer/rust/apt-requirements-base.json
@@ -5,5 +5,6 @@
   "gnupg2": "2.4.4-2ubuntu17",
   "libc6-dev": "2.39-0ubuntu8.1",
   "rustup": "1.26.0-5build1",
-  "wget": "1.21.4-1ubuntu4"
+  "wget": "1.21.4-1ubuntu4",
+  "xz-utils": "5.6.1+really5.4.5-1"
 }

--- a/.devcontainer/rust/test/testsuite.bats
+++ b/.devcontainer/rust/test/testsuite.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+bats_require_minimum_version 1.5.0
+
 setup() {
   load '/usr/local/bats-support/load'
   load '/usr/local/bats-assert/load'

--- a/.github/workflows/issue-creation-tool-versions.yml
+++ b/.github/workflows/issue-creation-tool-versions.yml
@@ -28,7 +28,6 @@ jobs:
           fi
           new_issue_url=$(gh issue create \
             --title "$TITLE" \
-            --assignee "$ASSIGNEES" \
             --label "$LABELS" \
             --body "$BODY")
           if [[ $PINNED == true ]]; then
@@ -38,12 +37,11 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TITLE: Evaluate tool versions
-          ASSIGNEES: awesome-embedded-projects
           LABELS: scheduled,tool-versions
           BODY: |
             ## Description
 
-            This issue is automatically created as a gentle reminder to evaluate and update the tool versions for the container image built from this repository.
+            This issue is automatically created as a gentle reminder to evaluate and update the tool versions for the container images built from this repository.
             The checklist below describes the steps that should be taken, and checked-off before this issue can be closed.
             Any decisions about purposefully not updating a tool to a newer version should be logged as issue comment.
             The general philosophy is to always include the latest tool versions and the latest [LTS](https://ubuntu.com/about/release-cycle) version of Ubuntu.
@@ -53,6 +51,8 @@ jobs:
 
             ## Checklist
 
+            ### amp-devcontainer-cpp
+
             - [ ] The [ARM GNU](https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads) toolchain is up to date and matches with the GCC version
             - [ ] The [Clang toolchain](https://apt.llvm.org/) is up to date
             - [ ] The [Docker cli](https://download.docker.com/linux/static/stable/) is up to date
@@ -60,5 +60,11 @@ jobs:
             - [ ] [Mull](https://github.com/mull-project/mull) is up to date and compatible with the currently installed Clang version
             - [ ] [include-what-you-use](https://github.com/include-what-you-use/include-what-you-use) is up to date and compatible with the currently installed Clang version
             - [ ] [xwin](https://github.com/Jake-Shadle/xwin) is up to date
+
+            ### amp-devcontainer-rust
+
+            - [ ] The [rust](https://rust-lang.org/) toolchain is up to date
+            - [ ] [rust-binstall](https://github.com/cargo-bins/cargo-binstall/releases) is up to date
+            - [ ] [bats-core](https://github.com/bats-core/bats-core), [bats-support](https://github.com/bats-core/bats-support) and [bats-assert](https://github.com/bats-core/bats-assert) are up to date
           PINNED: true
           CLOSE_PREVIOUS: true


### PR DESCRIPTION
# Pull Request

## Description of changes

This PR reworks the rust installation for Ubuntu 24.04. Several changes are included:

- rustup is installed via apt, as it is now part of the 24.04 packages
- rust is installed with the minimal profile, excluding docs, reducing image size with 700M
- additional rust tools are installed with cargo-binstall, removing the need for compilation from source

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the contribution guidelines for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
