### PR TITLE
docs: move manual test note on top when updating extensions

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -69,10 +69,10 @@ jobs:
           commit-message: "Update ${{ join(fromJson(steps.update-extensions.outputs.updated-dependencies), ', ') }}"
           branch: feature/update-vscode-extensions
           body: |
-            ${{ steps.update-extensions.outputs.markdown-summary }}
-
             > [!NOTE]
             > Before merging this PR, please conduct a manual test checking basic functionality of the updated plug-ins. There are no automated tests for the VS Code Extension updates.
+
+            ${{ steps.update-extensions.outputs.markdown-summary }}
           title: "chore(deps,${{ matrix.flavor }}): update ${{ join(fromJson(steps.update-extensions.outputs.updated-dependencies), ', ') }}"
           labels: dependencies,vscode-extensions
           token: ${{ steps.token.outputs.token }}


### PR DESCRIPTION
Swap the content and note in the PR body to prevent the note from falling-off because of overflow of summary text.

# Pull Request

## Description of changes

<!-- Fill in a description of what this PR changes/introduces/fixes
     Link to GitHub issues using keywords https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests when necessary
-->

Swap the content and note in the PR body to prevent the note from falling-off because of overflow of summary text.

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the contribution guidelines for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
