### PR TITLE
ci: add scope to GitHub Actions Docker build cache

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -76,8 +76,8 @@ jobs:
           annotations: ${{ steps.metadata.outputs.annotations }}
           sbom: true
           provenance: true
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.repository }}-${{ matrix.flavor }}
+          cache-to: type=gha,mode=max,scope=${{ github.repository }}-${{ matrix.flavor }}
       - uses: ./.github/actions/container-size-diff
         id: container-size-diff
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
           file: .devcontainer/${{ matrix.flavor }}/Dockerfile
           load: true
           tags: ${{ github.repository }}-${{ matrix.flavor }}:test
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.repository }}-${{ matrix.flavor }}
       - uses: actions/cache/restore@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
         if: matrix.flavor == 'cpp'
         with:

--- a/.github/workflows/prime-cache.yml
+++ b/.github/workflows/prime-cache.yml
@@ -25,8 +25,8 @@ jobs:
         with:
           file: .devcontainer/${{ matrix.flavor }}/Dockerfile
           platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=${{ github.repository }}-${{ matrix.flavor }}
+          cache-to: type=gha,mode=max,scope=${{ github.repository }}-${{ matrix.flavor }}
   prime-xwin-cache:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
# Pull Request

## Description of changes

<!-- Fill in a description of what this PR changes/introduces/fixes
     Link to GitHub issues using keywords https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests when necessary
-->

Since the introduction of multiple container flavors built from a ci matrix build, the scope property should be used to prevent overwriting of the Docker layer cache.

See: https://stackoverflow.com/questions/76227392/github-build-push-action-and-gha-cache-should-i-set-the-github-ref-name-in-the and https://docs.docker.com/build/cache/backends/gha/#scope.

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the contribution guidelines for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
