### PR TITLE
ci: prevent GitHub backlink creation on extension udpates

### DIFF
--- a/.github/actions/update-vscode-extensions/update-vscode-extensions.sh
+++ b/.github/actions/update-vscode-extensions/update-vscode-extensions.sh
@@ -8,6 +8,12 @@ EXTENSIONS=
 UPDATE_DETAILS_MARKDOWN=
 UPDATED_EXTENSIONS_JSON="[]"
 
+prevent_github_backlinks() {
+    # Prevent GitHub from creating backlinks to issues by replacing the URL with a non-redirecting one
+    # See: https://github.com/orgs/community/discussions/23123#discussioncomment-3239240
+    sed 's|https://github.com|https://www.github.com|g'
+}
+
 get_github_releasenotes() {
     local GITHUB_URL=${1:?}
     local CURRENT_RELEASE=${2:?}
@@ -37,7 +43,7 @@ for EXTENSION in $(echo $JSON | jq -r '.customizations.vscode.extensions | flatt
     then
         GITHUB_URL=$(echo $LATEST_NON_PRERELEASE_VERSION_JSON | jq -r '.properties | map(select(.key == "Microsoft.VisualStudio.Services.Links.GitHub"))[] | .value')
 
-        RELEASE_DETAILS=$(get_github_releasenotes $GITHUB_URL $CURRENT_VERSION)
+        RELEASE_DETAILS=$(get_github_releasenotes $GITHUB_URL $CURRENT_VERSION | prevent_github_backlinks)
         UPDATE_DETAILS_MARKDOWN=$(printf "Updates \`%s\` from %s to %s\n<details>\n<summary>Release notes</summary>\n<blockquote>\n\n%s\n</blockquote>\n</details>\n\n%s" $NAME $CURRENT_VERSION $LATEST_NON_PRERELEASE_VERSION "$RELEASE_DETAILS" "$UPDATE_DETAILS_MARKDOWN")
         UPDATED_EXTENSIONS_JSON=$(echo $UPDATED_EXTENSIONS_JSON | jq -c '. += ["'$NAME'"]')
     fi


### PR DESCRIPTION
# Pull Request

## Description of changes

Prevent GitHub from creating backlinks to issues mentioned in changlogs of VS Code Extensions that are updated automatically. Doing so prevents polluting extension PRs with amp-devcontainer links.

Following the advice in https://github.com/orgs/community/discussions/23123#discussioncomment-3239240.

Closes #477

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [ ] I have followed the contribution guidelines for this repository
- [ ] I have added tests for new behavior, and have not broken any existing tests
- [ ] I have added or updated relevant documentation
- [ ] I have verified that all added components are accounted for in the SBOM
