### PR TITLE
ci: differentiate branch name for vs code extension updates

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -67,7 +67,7 @@ jobs:
       - uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           commit-message: "Update ${{ join(fromJson(steps.update-extensions.outputs.updated-dependencies), ', ') }}"
-          branch: feature/update-vscode-extensions
+          branch: feature/amp-devcontainer-${{ matrix.flavor }}/update-vscode-extensions
           body: |
             > [!NOTE]
             > Before merging this PR, please conduct a manual test checking basic functionality of the updated plug-ins. There are no automated tests for the VS Code Extension updates.


### PR DESCRIPTION
# Pull Request

## Description of changes

The branch name for VS Code Extension updates did not take the matrix into account, overwriting previous PRs/branches made by a run of a different matrix parameter. This PR adds `matrix.flavor` to the branch name.

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [ ] I have followed the contribution guidelines for this repository
- [ ] I have added tests for new behavior, and have not broken any existing tests
- [ ] I have added or updated relevant documentation
- [ ] I have verified that all added components are accounted for in the SBOM
