### PR TITLE
test: add windows headers to clang-cl regression test

### DIFF
--- a/.devcontainer/cpp/test/clang-cl/main.cpp
+++ b/.devcontainer/cpp/test/clang-cl/main.cpp
@@ -1,4 +1,7 @@
 #include <iostream>
+#include <winsock2.h>
+#include <windows.h>
+#include <setupapi.h>
 
 int main()
 {


### PR DESCRIPTION
# Pull Request

## Description of changes

This PR adds several Windows SDK headers to the Windows cross compilation test with clang-cl. Making sure that the SDK is touched when doing the compilation.

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the contribution guidelines for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
