### PR TITLE
feat: update GCC toolchain to version 14.2

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -52,7 +52,7 @@ ENV PATH="$PATH:/usr/lib/llvm-${CLANG_VERSION}/bin"
 
 # Install arm-gcc toolchain
 RUN mkdir /opt/gcc-arm-none-eabi \
- && wget -qO - "https://developer.arm.com/-/media/Files/downloads/gnu/13.3.rel1/binrel/arm-gnu-toolchain-13.3.rel1-$(uname -m)-arm-none-eabi.tar.xz" | tar --exclude='*arm-none-eabi-gdb*' --exclude='share' --strip-components=1 -xJC /opt/gcc-arm-none-eabi
+ && wget -qO - "https://developer.arm.com/-/media/Files/downloads/gnu/14.2.rel1/binrel/arm-gnu-toolchain-14.2.rel1-$(uname -m)-arm-none-eabi.tar.xz" | tar --exclude='*arm-none-eabi-gdb*' --exclude='share' --strip-components=1 -xJC /opt/gcc-arm-none-eabi
 ENV PATH="$PATH:/opt/gcc-arm-none-eabi/bin"
 
 # Install docker-cli for Docker-from-Docker tools
@@ -97,9 +97,9 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
 
 # Update all tool alternatives to the correct version
 # and patch root's bashrc to include bash-completion
-RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-13 20 \
- && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-13 20 \
- && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-13 10 \
+RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 20 \
+ && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 20 \
+ && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-14 10 \
  && update-alternatives --install /usr/bin/iwyu iwyu /usr/local/bin/include-what-you-use 10 \
  && update-alternatives --install /usr/bin/mull-runner mull-runner /usr/local/bin/mull-runner-${CLANG_VERSION} 10 \
  && update-alternatives --install /usr/lib/mull-ir-frontend mull-ir-frontend /usr/local/lib/mull-ir-frontend-${CLANG_VERSION} 10 \

--- a/.devcontainer/cpp/apt-requirements-base.json
+++ b/.devcontainer/cpp/apt-requirements-base.json
@@ -1,7 +1,7 @@
 {
   "bash-completion": "1:2.11-8",
   "ca-certificates": "20240203",
-  "g++-13": "13.3.0-6ubuntu2~24.04",
+  "g++-14": "14.2.0-4ubuntu2~24.04",
   "gdb-multiarch": "15.0.50.20240403-0ubuntu1",
   "git": "1:2.43.0-1ubuntu7.1",
   "gnupg2": "2.4.4-2ubuntu17",

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -41,7 +41,7 @@ RUN batstmp="$(mktemp -d /tmp/bats-core-${BATS_VERSION}.XXXX)" \
 
 # Update all tool alternatives to the correct version
 # and patch root's bashrc to include bash-completion
-RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-13 20 \
+RUN update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 20 \
  && cp /etc/skel/.bashrc /root/.bashrc
 
 ENV BINSTALL_DISABLE_TELEMETRY=true

--- a/.devcontainer/rust/apt-requirements-base.json
+++ b/.devcontainer/rust/apt-requirements-base.json
@@ -1,7 +1,7 @@
 {
   "bash-completion": "1:2.11-8",
   "ca-certificates": "20240203",
-  "g++-13": "13.3.0-6ubuntu2~24.04",
+  "g++-14": "14.2.0-4ubuntu2~24.04",
   "git": "1:2.43.0-1ubuntu7.1",
   "gnupg2": "2.4.4-2ubuntu17",
   "libc6-dev": "2.39-0ubuntu8.3",

--- a/test/cpp/workspace/CMakeLists.txt
+++ b/test/cpp/workspace/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.30)
 project(devcontainer-test LANGUAGES ASM C CXX)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_SCAN_FOR_MODULES Off)
 
 include(CTest)
 include(GoogleTest)


### PR DESCRIPTION
# Pull Request

## Description of changes

This PR includes an update to the GCC and ARM GCC toolchain to version 14.2.

See [this](https://gcc.gnu.org/gcc-14/changes.html) page for an overview of changes. Or [this](https://www.meetingcpp.com/blog/items/What-brings-an-upgrade-to-GCC-14-from-GCC-13-.html) page for an overview from a user's perspective.

## Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the contribution guidelines for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
