### PR TITLE
fix: prevent GitHub at mentions in quoted release notes

### DIFF
--- a/.github/actions/update-vscode-extensions/update-vscode-extensions.sh
+++ b/.github/actions/update-vscode-extensions/update-vscode-extensions.sh
@@ -14,6 +14,10 @@ prevent_github_backlinks() {
     sed 's|https://github.com|https://www.github.com|g'
 }
 
+prevent_github_at_mentions() {
+    sed 's| @| [at]|g'
+}
+
 get_github_releasenotes() {
     local GITHUB_URL=${1:?}
     local CURRENT_RELEASE=${2:?}
@@ -43,7 +47,7 @@ for EXTENSION in $(echo $JSON | jq -r '.customizations.vscode.extensions | flatt
     then
         GITHUB_URL=$(echo $LATEST_NON_PRERELEASE_VERSION_JSON | jq -r '.properties | map(select(.key == "Microsoft.VisualStudio.Services.Links.GitHub"))[] | .value')
 
-        RELEASE_DETAILS=$(get_github_releasenotes $GITHUB_URL $CURRENT_VERSION | prevent_github_backlinks)
+        RELEASE_DETAILS=$(get_github_releasenotes $GITHUB_URL $CURRENT_VERSION | prevent_github_backlinks | prevent_github_at_mentions)
         UPDATE_DETAILS_MARKDOWN=$(printf "Updates \`%s\` from %s to %s\n<details>\n<summary>Release notes</summary>\n<blockquote>\n\n%s\n</blockquote>\n</details>\n\n%s" $NAME $CURRENT_VERSION $LATEST_NON_PRERELEASE_VERSION "$RELEASE_DETAILS" "$UPDATE_DETAILS_MARKDOWN")
         UPDATED_EXTENSIONS_JSON=$(echo $UPDATED_EXTENSIONS_JSON | jq -c '. += ["'$NAME'"]')
     fi


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

Replace instances of @... to [at]... to prevent GitHub from mentioning users that contributed fixes of automated extension updates

Closes #679

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
