### PR TITLE
chore: switch to GitHub attestations

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -22,13 +22,13 @@ jobs:
   build-push:
     runs-on: ubuntu-latest
     permissions:
+      attestations: write
       # dependency-submission needs contents write permission.
       contents: write
+      # attest-build-provenance needs id-token write permission.
+      id-token: write
       packages: write
       pull-requests: write
-      # This is used to complete the identity challenge
-      # with sigstore/fulcio when running outside of PRs.
-      id-token: write
     strategy:
       matrix:
         flavor: ["cpp", "rust"]
@@ -39,8 +39,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-      - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
-        if: github.event_name != 'merge_group'
       - uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
       - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         if: github.event_name != 'merge_group'
@@ -121,14 +119,18 @@ jobs:
         with:
           comment-summary-in-pr: on-failure
           fail-on-severity: critical
-      - name: Sign the images with GitHub OIDC token
+      - uses: actions/attest-build-provenance@7668571508540a607bdfd90a87a560489fe372eb # v2.1.0
         if: github.event_name != 'merge_group'
-        # This step uses the GitHub OIDC identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}
+          subject-digest: ${{ steps.build-and-push.outputs.digest }}
+          push-to-registry: true
+      - name: Verify attestation
+        if: github.event_name != 'merge_group'
         env:
-          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          cosign sign --yes --recursive "${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}@${DIGEST}"
+          gh attestation verify oci://${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }} --owner "$GITHUB_REPOSITORY_OWNER"
   acceptance-test:
     if: github.event_name == 'pull_request'
     needs: build-push

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -130,7 +130,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh attestation verify oci://${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }} --owner "$GITHUB_REPOSITORY_OWNER"
+          gh attestation verify --owner "$GITHUB_REPOSITORY_OWNER" oci://${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}@${{ steps.build-and-push.outputs.digest }}
   acceptance-test:
     if: github.event_name == 'pull_request'
     needs: build-push

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -96,7 +96,6 @@ jobs:
             devcontainer.metadata=${{ steps.devcontainer-metadata.outputs.metadata }}
           annotations: ${{ steps.metadata.outputs.annotations }}
           sbom: true
-          provenance: true
           cache-from: type=gha,scope=${{ github.repository }}-${{ matrix.flavor }}
           cache-to: type=gha,mode=max,scope=${{ github.repository }}-${{ matrix.flavor }}
       - uses: ./.github/actions/container-size-diff
@@ -130,7 +129,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh attestation verify --owner "$GITHUB_REPOSITORY_OWNER" oci://${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}@${{ steps.build-and-push.outputs.digest }}
+          gh attestation verify --repo ${{ github.repository }} oci://${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}@${{ steps.build-and-push.outputs.digest }}
   acceptance-test:
     if: github.event_name == 'pull_request'
     needs: build-push

--- a/.github/workflows/package-published.yml
+++ b/.github/workflows/package-published.yml
@@ -1,0 +1,16 @@
+---
+name: Package Published
+
+on:
+  registry_package:
+    types: [published]
+
+jobs:
+  attach-provenance-to-release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          set -Eeuo pipefail
+          echo "${{ toJson(github.event.registry_package) }}" | jq .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package-published.yml
+++ b/.github/workflows/package-published.yml
@@ -5,6 +5,9 @@ on:
   registry_package:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   attach-provenance-to-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-image-cleanup.yml
+++ b/.github/workflows/pr-image-cleanup.yml
@@ -20,13 +20,11 @@ jobs:
     permissions:
       packages: write
     steps:
-      - uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
       - uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - run: cosign clean -f --type=signature "${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}:pr-${{ github.event.pull_request.number }}"
       - uses: bots-house/ghcr-delete-image-action@3827559c68cb4dcdf54d813ea9853be6d468d3a4 # v1.1.0
         with:
           owner: ${{ github.repository_owner }}

--- a/.github/workflows/social-interaction.yml
+++ b/.github/workflows/social-interaction.yml
@@ -3,7 +3,9 @@ name: Social Interaction
 
 on:
   issues:
+    types: [opened]
   pull_request:
+    types: [opened]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Both containers can be used in Visual Studio Code or GitHub Codespaces without a
 
 ### Verify image signature
 
+<details><summary>Prior to version 5.6.0</summary>
+
 The container images are signed with [SigStore](https://www.sigstore.dev/) [Cosign](https://docs.sigstore.dev/cosign/signing/overview/) using a keyless signing method.
 
 The signature can be [verified](https://docs.sigstore.dev/cosign/verifying/verify/) with the following command (using Docker), verifying that the image is actually signed by the GitHub CI system:
@@ -69,12 +71,33 @@ docker run --rm gcr.io/projectsigstore/cosign verify ghcr.io/philips-software/am
 docker run --rm gcr.io/projectsigstore/cosign verify ghcr.io/philips-software/amp-devcontainer-rust --certificate-oidc-issuer https://token.actions.githubusercontent.com --certificate-identity-regexp https://github.com/philips-software/amp-devcontainer
 ```
 
+</details>
+
+The container images are signed using the [attest-build-provenance](https://github.com/actions/attest-build-provenance) action.
+
+The attestations can be checked with the following command, verifying that the image is actually built by the GitHub CI system:
+
+> amp-devcontainer-cpp
+
+```sh
+gh attestation verify --repo philips-software/amp-devcontainer oci://ghcr.io/philips-software/amp-devcontainer-cpp
+```
+
+> amp-devcontainer-rust
+
+```sh
+gh attestation verify --repo philips-software/amp-devcontainer oci://ghcr.io/philips-software/amp-devcontainer-rust
+```
+
+### Local development
+
 The resulting containers can be used in a `.devcontainer.json` file or in a `.devcontainer` folder.
 
 > [!NOTE]
 > While the following examples use the `latest` tag, it is recommended to pin to a specific version. Or better yet, a specific SHA.
+> See the [releases](https://github.com/philips-software/amp-devcontainer/releases) for the SHA corresponding to a specific release.
 
-### amp-devcontainer-cpp
+#### amp-devcontainer-cpp
 
 > .devcontainer/devcontainer.json or .devcontainer.json
 
@@ -84,7 +107,7 @@ The resulting containers can be used in a `.devcontainer.json` file or in a `.de
 }
 ```
 
-### amp-devcontainer-rust
+#### amp-devcontainer-rust
 
 > .devcontainer/devcontainer.json or .devcontainer.json
 


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This PR changes the way the amp-devcontainer images are signed. It moves away from using Cosign and Sigstore directly, instead [attest-build-provenance](https://github.com/actions/attest-build-provenance) is used.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
