### PR TITLE
ci: run prime-docker-cache on ubuntu-22.04

### DIFF
--- a/.github/workflows/package-published.yml
+++ b/.github/workflows/package-published.yml
@@ -3,7 +3,6 @@ name: Package Published
 
 on:
   registry_package:
-    types: [updated]
 
 permissions:
   contents: read

--- a/.github/workflows/prime-cache.yml
+++ b/.github/workflows/prime-cache.yml
@@ -14,7 +14,8 @@ concurrency:
 
 jobs:
   prime-docker-cache:
-    runs-on: ubuntu-latest
+    # The ARM64 build segfaults with Ubuntu 24.04, so use 22.04 (for now)
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         flavor: ["cpp", "rust"]


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

Running the emulated arm64 build causes a segfault on Ubuntu 24.04 at the moment. This PR switches the default runner (based on Ubuntu 24.04) back to the previous version for the prime cache workflow.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
