### PR TITLE
ci: automatically update release notes with image details

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -9,7 +9,7 @@
 #### :bookmark: Packages
 
 | Container             | Full identifier                                                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------|
 | amp-devcontainer-cpp  | ghcr.io/philips-software/amp-devcontainer-cpp:{{ amp-devcontainer-cpp-version }}@sha256:{{ amp-devcontainer-cpp-sha }}    |
 | amp-devcontainer-rust | ghcr.io/philips-software/amp-devcontainer-rust:{{ amp-devcontainer-rust-version }}@sha256:{{ amp-devcontainer-rust-sha }} |
 

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable MD041 -->
 
 ### :clipboard: Summary
 

--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,14 @@
+
+### :clipboard: Summary
+
+<!-- Manually fill this summary, taking note of any changes relevant to the end user.
+     When a change requires action, or emphasis, use '> [!NOTE]' notation.
+-->
+
+#### :bookmark: Packages
+
+| Container             | Full identifier                                                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| amp-devcontainer-cpp  | ghcr.io/philips-software/amp-devcontainer-cpp:{{ amp-devcontainer-cpp-version }}@sha256:{{ amp-devcontainer-cpp-sha }}    |
+| amp-devcontainer-rust | ghcr.io/philips-software/amp-devcontainer-rust:{{ amp-devcontainer-rust-version }}@sha256:{{ amp-devcontainer-rust-sha }} |
+

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -136,15 +136,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh attestation verify --repo ${{ github.repository }} oci://${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}@${{ steps.build-and-push.outputs.digest }} --format json --jq '.[] | .attestation.bundle.dsseEnvelope | select(.payloadType == "application/vnd.in-toto+json").payload' | base64 -d | jq . > ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ matrix.flavor }}_sha256_${{ steps.build-and-push.outputs.digest }}.intoto.jsonl
-          gh release upload ${{ github.ref_name }} *.intoto.jsonl
+          gh release upload ${{ github.ref_name }} ./*.intoto.jsonl
       - name: Update package details in release
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           UPDATED_NOTES=$(gh release view ${{ github.ref_name }} --json body -q '.body')
-          UPDATED_NOTES=$(echo "$UPDATED_NOTES" | sed "s/{{ amp-devcontainer-${{ matrix.flavor }}-version }}/${{ github.ref_name }}")
-          UPDATED_NOTES=$(echo "$UPDATED_NOTES" | sed "s/{{ amp-devcontainer-${{ matrix.flavor }}-sha }}/${{ steps.build-and-push.outputs.digest }}")
+          UPDATED_NOTES=$(echo "$UPDATED_NOTES" | sed "s/{{ amp-devcontainer-${{ matrix.flavor }}-version }}/${{ github.ref_name }}/g")
+          UPDATED_NOTES=$(echo "$UPDATED_NOTES" | sed "s/{{ amp-devcontainer-${{ matrix.flavor }}-sha }}/${{ steps.build-and-push.outputs.digest }}/g")
           gh release edit ${{ github.ref_name }} --notes "${UPDATED_NOTES}"
   acceptance-test:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -130,6 +130,22 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh attestation verify --repo ${{ github.repository }} oci://${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}@${{ steps.build-and-push.outputs.digest }}
+      - name: Upload provenance to release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh attestation verify --repo ${{ github.repository }} oci://${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}@${{ steps.build-and-push.outputs.digest }} --format json --jq '.[] | .attestation.bundle.dsseEnvelope | select(.payloadType == "application/vnd.in-toto+json").payload' | base64 -d | jq . > ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ matrix.flavor }}_sha256_${{ steps.build-and-push.outputs.digest }}.intoto.jsonl
+          gh release upload ${{ github.ref_name }} *.intoto.jsonl
+      - name: Update package details in release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          UPDATED_NOTES=$(gh release view ${{ github.ref_name }} --json body -q '.body')
+          UPDATED_NOTES=$(echo "$UPDATED_NOTES" | sed "s/{{ amp-devcontainer-${{ matrix.flavor }}-version }}/${{ github.ref_name }}")
+          UPDATED_NOTES=$(echo "$UPDATED_NOTES" | sed "s/{{ amp-devcontainer-${{ matrix.flavor }}-sha }}/${{ steps.build-and-push.outputs.digest }}")
+          gh release edit ${{ github.ref_name }} --notes "${UPDATED_NOTES}"
   acceptance-test:
     if: github.event_name == 'pull_request'
     needs: build-push

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -143,8 +143,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           UPDATED_NOTES=$(gh release view ${{ github.ref_name }} --json body -q '.body')
-          UPDATED_NOTES=$(echo "$UPDATED_NOTES" | sed "s/{{ amp-devcontainer-${{ matrix.flavor }}-version }}/${{ github.ref_name }}/g")
-          UPDATED_NOTES=$(echo "$UPDATED_NOTES" | sed "s/{{ amp-devcontainer-${{ matrix.flavor }}-sha }}/${{ steps.build-and-push.outputs.digest }}/g")
+          UPDATED_NOTES=${UPDATED_NOTES//'{{ amp-devcontainer-${{ matrix.flavor }}-version }}'/'${{ github.ref_name }}'}
+          UPDATED_NOTES=${UPDATED_NOTES//'{{ amp-devcontainer-${{ matrix.flavor }}-sha }}'/'${{ steps.build-and-push.outputs.digest }}'}
           gh release edit ${{ github.ref_name }} --notes "${UPDATED_NOTES}"
   acceptance-test:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,5 +22,16 @@ jobs:
           app-id: ${{ vars.FOREST_RELEASER_APP_ID }}
           private-key: ${{ secrets.FOREST_RELEASER_APP_PRIVATE_KEY }}
       - uses: googleapis/release-please-action@a02a34c4d625f9be7cb89156071d8567266a2445 # v4.2.0
+        id: release
         with:
           token: ${{ steps.token.outputs.token }}
+      - name: Amend release description
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          CURRENT_NOTES=$(gh release view ${{ steps.release.outputs.tag_name }} --json body -q '.body')
+          HEADER=$(echo "$CURRENT_NOTES" | awk '/^## / {print; exit}')
+          TEMPLATE=$(cat ../RELEASE_TEMPLATE.md)
+          BODY=$(echo "$CURRENT_NOTES" | sed "0,/^## /d")
+          gh release edit ${{ steps.release.outputs.tag_name }} --notes "${HEADER}${TEMPLATE}${BODY}"


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

Previously, when a new version was released, manual effort was required to fill in package details in the release notes.

This PR adds functionality to automatically:

- Fill in version and sha details of the published packages in the release notes
- Add SLSA provenance artifacts to the release

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
