### PR TITLE
ci: fix release template generation (again)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,6 +35,6 @@ jobs:
         run: |
           CURRENT_NOTES=$(gh release view ${{ steps.release.outputs.tag_name }} --json body -q '.body')
           HEADER=$(echo "$CURRENT_NOTES" | awk '/^## / {print; exit}')
-          TEMPLATE=$(cat ../RELEASE_TEMPLATE.md)
+          TEMPLATE=$(cat "$GITHUB_WORKSPACE/.github/RELEASE_TEMPLATE.md")
           BODY=$(echo "$CURRENT_NOTES" | sed "0,/^## /d")
           gh release edit ${{ steps.release.outputs.tag_name }} --notes "${HEADER}${TEMPLATE}${BODY}"


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This PR fixes the release note generation by specifying the correct path to the template.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
