### PR TITLE
feat: add alternatives for gcc and g++

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -95,13 +95,15 @@ RUN --mount=type=cache,target=/root/.ccache,sharing=locked \
 
 # Update all tool alternatives to the correct version
 # and patch root's bashrc to include bash-completion
-RUN update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 20 \
- && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 20 \
- && update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-14 10 \
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 10 \
+                        --slave /usr/bin/g++ g++ /usr/bin/g++-14 \
+                        --slave /usr/bin/gcov gcov /usr/bin/gcov-14 \
+ && update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-14 10 \
+                        --slave /usr/bin/c++ c++ /usr/bin/g++-14 \
  && update-alternatives --install /usr/bin/iwyu iwyu /usr/local/bin/include-what-you-use 10 \
  && update-alternatives --install /usr/bin/mull-runner mull-runner /usr/bin/mull-runner-${CLANG_VERSION} 10 \
- && update-alternatives --install /usr/bin/mull-reporter mull-reporter /usr/bin/mull-reporter-${CLANG_VERSION} 10 \
- && update-alternatives --install /usr/lib/mull-ir-frontend mull-ir-frontend /usr/lib/mull-ir-frontend-${CLANG_VERSION} 10 \
+                        --slave /usr/bin/mull-reporter mull-reporter /usr/bin/mull-reporter-${CLANG_VERSION} \
+                        --slave /usr/lib/mull-ir-frontend mull-ir-frontend /usr/lib/mull-ir-frontend-${CLANG_VERSION} \
  && update-alternatives --install /usr/bin/python python /usr/bin/python3 10 \
  && cp /etc/skel/.bashrc /root/.bashrc
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run Tests
         run: |
           set -Eeuo pipefail
-          docker run --rm --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock --mount type=bind,src="${{ github.workspace }}/test/${{ matrix.flavor }}",dst=/ws -w /ws ${{ github.repository }}-${{ matrix.flavor }}:test bats --formatter junit integration-tests.bats | tee test-report-${{ matrix.flavor }}.xml
+          docker run --rm --mount type=bind,src=/var/run/docker.sock,dst=/var/run/docker.sock --mount type=bind,src="${{ github.workspace }}",dst=/ws -w /ws ${{ github.repository }}-${{ matrix.flavor }}:test bats --formatter junit test/${{ matrix.flavor }}/integration-tests.bats | tee test-report-${{ matrix.flavor }}.xml
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CPM)
 
 project(devcontainer-test "NONE")
 
-CPMAddPackage("gh:neonsoftware/cmake-bats@0.0.3")
+CPMAddPackage("gh:neonsoftware/cmake-bats#53562f5a9be517944fb8a2df3ea80f81f17e070c")
 
 enable_testing()
 bats_discover_tests("${CMAKE_CURRENT_SOURCE_DIR}/test/$ENV{CONTAINER_FLAVOR}/integration-tests.bats")

--- a/test/cpp/integration-tests.bats
+++ b/test/cpp/integration-tests.bats
@@ -2,6 +2,10 @@
 
 bats_require_minimum_version 1.5.0
 
+setup_file() {
+  install_win_sdk_when_ci_set
+}
+
 teardown_file() {
   rm -rf ${BATS_TEST_DIRNAME}/.xwin-hash/ /winsdk
 }
@@ -84,7 +88,7 @@ teardown() {
 }
 
 @test "valid code input should result in Windows executable using clang-cl compiler" {
-  install_win_sdk
+  install_win_sdk_when_ci_unset
 
   cmake --preset clang-cl
   cmake --build --preset clang-cl
@@ -108,7 +112,7 @@ teardown() {
 }
 
 @test "using ccache as a compiler launcher should result in cached build using clang-cl compiler" {
-  install_win_sdk
+  install_win_sdk_when_ci_unset
 
   configure_and_build_with_ccache clang-cl
 }
@@ -286,4 +290,22 @@ function install_win_sdk() {
   fi
 
   ln -sf ${BATS_TEST_DIRNAME}/.xwin-cache/splat/ /winsdk
+}
+
+function install_win_sdk_when_ci_unset() {
+  # When running tests locally we typically run them one by one,
+  # and want to install the Win SDK only for each test that requires it.
+
+  if [[ -z "${CI}" ]]; then
+    install_win_sdk
+  fi
+}
+
+function install_win_sdk_when_ci_set() {
+  # When running on a CI environment we run all tests in a single batch,
+  # and only want to install the Win SKD once.
+
+  if [[ -n "${CI}" ]]; then
+    install_win_sdk
+  fi
 }

--- a/test/cpp/integration-tests.bats
+++ b/test/cpp/integration-tests.bats
@@ -7,8 +7,8 @@ setup_file() {
   # When still valid, use the installation from cache.
 
   xwin --accept-license --manifest-version 16 --cache-dir ${BATS_TEST_DIRNAME}/.xwin-hash list
-  HASH_LIST_MANIFEST=$(sha256sum ${BATS_TEST_DIRNAME}/.xwin-hash/dl/manifest*.json | awk '{ print $1 }')
-  HASH_CACHED_MANIFEST=
+  local HASH_LIST_MANIFEST=$(sha256sum ${BATS_TEST_DIRNAME}/.xwin-hash/dl/manifest*.json | awk '{ print $1 }')
+  local HASH_CACHED_MANIFEST=
 
   if [[ -d ${BATS_TEST_DIRNAME}/.xwin-cache/dl ]]; then
     HASH_CACHED_MANIFEST=$(sha256sum ${BATS_TEST_DIRNAME}/.xwin-cache/dl/manifest*.json | awk '{ print $1 }')
@@ -48,6 +48,12 @@ teardown() {
 
   INSTALLED_GCOV_VERSION=$(gcov --version | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -n1)
   assert_equal $INSTALLED_GCOV_VERSION $EXPECTED_VERSION
+}
+
+@test "host and embedded gcc toolchain versions should be the same major and minor version" {
+  EXPECTED_MAJOR_MINOR_VERSION=$(get_expected_version_for g++ | cut -d. -f1,2)
+  INSTALLED_MAJOR_MINOR_VERSION=$(arm-none-eabi-gcc -dumpfullversion | cut -d. -f1,2)
+  assert_equal $INSTALLED_MAJOR_MINOR_VERSION $EXPECTED_MAJOR_MINOR_VERSION
 }
 
 @test "valid code input should result in working executable using host compiler" {

--- a/test/cpp/workspace/test/CMakeLists.txt
+++ b/test/cpp/workspace/test/CMakeLists.txt
@@ -4,8 +4,7 @@ option(ENABLE_MUTATION_TESTING_TEST Off)
 include(FetchContent)
 
 FetchContent_Declare(googletest
-    GIT_REPOSITORY https://github.com/google/googletest
-    GIT_TAG v1.15.2
+    URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
 )
 
 if (ENABLE_COVERAGE_TEST)


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

Adding gcc and g++ alternatives pointing to the correct version of gcc prevents overwriting gcc and g++ by installers of the test environment. In the process switch to --slave options for g++/c++.

Added test that checks for consistent versions corresponding with the requested version from the json version file.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
