### PR TITLE
test: fix toolchain for arm64 hosts

### DIFF
--- a/test/cpp/workspace/clang-cl/toolchain.cmake
+++ b/test/cpp/workspace/clang-cl/toolchain.cmake
@@ -19,4 +19,4 @@ find_program(CMAKE_CXX_COMPILER NAMES clang-cl REQUIRED)
 find_program(CMAKE_AR NAMES llvm-lib REQUIRED)
 
 add_compile_options(--target=x86_64-pc-windows-msvc -fuse-ld=lld /winsdkdir ${WINDOWS_SDK_ROOT}/sdk /vctoolsdir ${WINDOWS_SDK_ROOT}/crt)
-add_link_options(/manifest:no -libpath:${WINDOWS_SDK_ROOT}/sdk/lib/um/x64 -libpath:${WINDOWS_SDK_ROOT}/sdk/lib/ucrt/x64 -libpath:${WINDOWS_SDK_ROOT}/crt/lib/x64)
+add_link_options(/machine:x64 /manifest:no -libpath:${WINDOWS_SDK_ROOT}/sdk/lib/um/x64 -libpath:${WINDOWS_SDK_ROOT}/sdk/lib/ucrt/x64 -libpath:${WINDOWS_SDK_ROOT}/crt/lib/x64)

--- a/test/cpp/workspace/fuzzing/main.cpp
+++ b/test/cpp/workspace/fuzzing/main.cpp
@@ -1,10 +1,11 @@
 #include <cstdint>
+#include <cstdlib>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, std::size_t size)
 {
     if (size > 0 && data[0] == 'H')
         if (size > 1 && data[1] == 'I')
-            __builtin_trap();
+            abort();
 
     return 0;
 }


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

On arm64 hosts lld-link seems to default to /machine:ARM64 which is incorrect for the cross-compile use-case. Set the machine type to x64.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
