### PR TITLE
test: enable arm runners in ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,11 @@ permissions:
 
 jobs:
   build-test:
-    runs-on: ubuntu-latest
     strategy:
       matrix:
         flavor: ["cpp", "rust"]
+        runner: ["ubuntu-latest", "ubuntu-24.04-arm"]
+    runs-on: ${{ matrix.runner }}
     steps:
       # While the docker/build-push-action works from the Git context, we still need
       # the checkout step for running our tests.
@@ -30,8 +31,8 @@ jobs:
         with:
           file: .devcontainer/${{ matrix.flavor }}/Dockerfile
           load: true
-          tags: ${{ github.repository }}-${{ matrix.flavor }}:test
-          cache-from: type=gha,scope=${{ github.repository }}-${{ matrix.flavor }}
+          tags: ${{ github.repository }}-${{ matrix.flavor }}-${{ matrix.runner }}:test
+          cache-from: type=gha,scope=${{ github.repository }}-${{ matrix.flavor }}-${{ matrix.runner }}
       - uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: matrix.flavor == 'cpp'
         with:
@@ -46,7 +47,7 @@ jobs:
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: always()
         with:
-          name: test-results-${{ matrix.flavor }}
+          name: test-results-${{ matrix.flavor }}-${{ matrix.runner }}
           path: test-report-*.xml
   publish-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This enables running of the container build and test workflow on ARM64 hardware. This ensures future compatibility with ARM64 hosts and reduces the need for manual testing.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
