### PR TITLE
ci: enable more harden-runner features

### DIFF
--- a/.github/workflows/issue-cleanup.yml
+++ b/.github/workflows/issue-cleanup.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:

--- a/.github/workflows/issue-creation-tool-versions.yml
+++ b/.github/workflows/issue-creation-tool-versions.yml
@@ -17,6 +17,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - run: |
           if [[ $CLOSE_PREVIOUS == true ]]; then

--- a/.github/workflows/linting-formatting.yml
+++ b/.github/workflows/linting-formatting.yml
@@ -4,6 +4,10 @@ name: Linting & Formatting
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    # Run on push to main, this is not actionable
+    # but it gives us a baseline for PRs
+    branches: [main]
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
@@ -23,6 +27,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -20,6 +20,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/pr-conventional-title.yml
+++ b/.github/workflows/pr-conventional-title.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         id: pr-title

--- a/.github/workflows/pr-conventional-title.yml
+++ b/.github/workflows/pr-conventional-title.yml
@@ -19,7 +19,9 @@ jobs:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
           disable-sudo-and-containers: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         id: pr-title
         with:

--- a/.github/workflows/pr-image-cleanup.yml
+++ b/.github/workflows/pr-image-cleanup.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
         with:
@@ -41,6 +42,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - run: |
           gh extension install actions/gh-actions-cache

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -34,6 +34,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -62,6 +63,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - name: Inspect manifest and extract digest
         id: inspect-manifest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: rdlf0/comment-released-prs-action@a81897eaea04a5faa8779d28607826ddb033321a # v3.1.0
         with:

--- a/.github/workflows/social-interaction.yml
+++ b/.github/workflows/social-interaction.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: actions/first-interaction@34f15e814fe48ac9312ccf29db4e74fa767cbab7 # v1.3.0
         continue-on-error: true

--- a/.github/workflows/social-interaction.yml
+++ b/.github/workflows/social-interaction.yml
@@ -20,7 +20,9 @@ jobs:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
           disable-sudo-and-containers: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - uses: actions/first-interaction@34f15e814fe48ac9312ccf29db4e74fa767cbab7 # v1.3.0
         continue-on-error: true
         with:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+      - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/wc-acceptance-test.yml
+++ b/.github/workflows/wc-acceptance-test.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/wc-acceptance-test.yml
+++ b/.github/workflows/wc-acceptance-test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
-          disable-sudo-and-containers: true
+          # Playwright requires root privileges to install browsers
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/wc-build-push-test.yml
+++ b/.github/workflows/wc-build-push-test.yml
@@ -37,7 +37,7 @@ jobs:
     needs: build-push
     if: github.event_name == 'pull_request'
     steps:
-      - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+      - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
           disable-sudo-and-containers: true
           egress-policy: audit

--- a/.github/workflows/wc-build-push-test.yml
+++ b/.github/workflows/wc-build-push-test.yml
@@ -39,6 +39,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
         with:
+          disable-sudo-and-containers: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -80,6 +81,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo: true
           egress-policy: audit
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -30,6 +30,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -99,6 +100,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/wc-integration-test.yml
+++ b/.github/workflows/wc-integration-test.yml
@@ -26,6 +26,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo: true
           egress-policy: audit
       - run: echo "arch=${RUNNER_ARCH@L}" >> "$GITHUB_OUTPUT"
         id: runner-arch
@@ -43,6 +44,7 @@ jobs:
     steps:
       - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
         with:
+          disable-sudo: true
           egress-policy: audit
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This PR enables `disable-sudo` and `disable-sudo-and-containers` where possible. And it enables the `block` policy on jobs that have a stable baseline.

> [!NOTE]
> We are aware that step-security/harden-runner currently does not work on ARM runners and on job that themselves run in containers (via `container:`). We have purposely not excluded the step from those jobs, as support might come in the future.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
