### PR TITLE
feat: implement better clean up strategy

### DIFF
--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -1,0 +1,26 @@
+---
+name: Cleanup Images
+
+on:
+  schedule:
+    - cron: "30 1 * * *"
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  delete-images:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          disable-sudo: true
+          egress-policy: audit
+      - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
+        with:
+          dry-run: true
+          delete-orphaned-images: true
+          packages: amp-devcontainer-cpp, amp-devcontainer-rust

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -23,4 +23,4 @@ jobs:
         with:
           dry-run: true
           delete-orphaned-images: true
-          packages: amp-devcontainer-cpp, amp-devcontainer-rust
+          packages: amp-devcontainer-cpp,amp-devcontainer-rust

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -4,7 +4,6 @@ name: Cleanup Images
 on:
   schedule:
     - cron: "0 0 * * 3"
-  pull_request:
   workflow_dispatch:
 
 permissions: {}

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -26,7 +26,6 @@ jobs:
             ghcr.io:443
       - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          dry-run: true
           delete-orphaned-images: true
           delete-untagged: true
           packages: amp-devcontainer,amp-devcontainer-cpp,amp-devcontainer-rust

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -24,6 +24,5 @@ jobs:
             ghcr.io:443
       - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          dry-run: true
           delete-orphaned-images: true
           packages: amp-devcontainer,amp-devcontainer-cpp,amp-devcontainer-rust

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -18,9 +18,12 @@ jobs:
       - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           disable-sudo: true
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            ghcr.io:443
       - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
           dry-run: true
           delete-orphaned-images: true
-          packages: amp-devcontainer-cpp,amp-devcontainer-rust
+          packages: amp-devcontainer,amp-devcontainer-cpp,amp-devcontainer-rust

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -3,7 +3,7 @@ name: Cleanup Images
 
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "0 0 * * 3"
   pull_request:
   workflow_dispatch:
 
@@ -13,6 +13,8 @@ jobs:
   delete-images:
     runs-on: ubuntu-latest
     permissions:
+      # dataaxiom/ghcr-cleanup-action needs packages write permission
+      # to delete untagged and orphaned images
       packages: write
     steps:
       - uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -24,5 +26,7 @@ jobs:
             ghcr.io:443
       - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
+          dry-run: true
           delete-orphaned-images: true
+          delete-untagged: true
           packages: amp-devcontainer,amp-devcontainer-cpp,amp-devcontainer-rust

--- a/.github/workflows/pr-image-cleanup.yml
+++ b/.github/workflows/pr-image-cleanup.yml
@@ -7,15 +7,9 @@ on:
 
 permissions: {}
 
-env:
-  REGISTRY: ghcr.io
-
 jobs:
   delete-images:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        flavor: ["cpp", "rust"]
     permissions:
       packages: write
     steps:
@@ -23,17 +17,10 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: audit
-      - uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
+      - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: bots-house/ghcr-delete-image-action@3827559c68cb4dcdf54d813ea9853be6d468d3a4 # v1.1.0
-        with:
-          owner: ${{ github.repository_owner }}
-          name: ${{ github.event.repository.name }}-${{ matrix.flavor }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: pr-${{ github.event.pull_request.number }}
+          delete-tags: pr-${{ github.event.pull_request.number }}
+          packages: amp-devcontainer-cpp, amp-devcontainer-rust
   cleanup-cache:
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/pr-image-cleanup.yml
+++ b/.github/workflows/pr-image-cleanup.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
           delete-tags: pr-${{ github.event.pull_request.number }}
-          packages: amp-devcontainer-cpp, amp-devcontainer-rust
+          packages: amp-devcontainer,amp-devcontainer-cpp,amp-devcontainer-rust
   cleanup-cache:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This PR implements a better cleanup strategy for container images by replacing the existing bots-house/ghcr-delete-image-action with dataaxiom/ghcr-cleanup-action and adding a new scheduled workflow for general image cleanup.

From now on a regular cron job will run, next to the already present PR image cleanup, to remove orphaned and untagged images. This means all images that are not part of a parent with a tag will be removed. Including multi-arch images and attestations and signatures. 

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
