### PR TITLE
chore(deps, cpp): update ccache to 4.12

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04@sha256:9cbed754112939e914291337b5e554b07ad7c392491dba6daf25eef1332a22e8
 
 ARG BATS_VERSION=1.11.0
-ARG CCACHE_VERSION=4.11
+ARG CCACHE_VERSION=4.12
 ARG CLANG_VERSION=18
 ARG CPM_VERSION=0.40.2
 ARG INCLUDE_WHAT_YOU_USE_VERSION=0.22
@@ -68,16 +68,9 @@ RUN batstmp="$(mktemp -d /tmp/bats-core-${BATS_VERSION}.XXXX)" \
  && git -C /usr/local clone -b v0.3.0 https://github.com/bats-core/bats-support.git \
  && git -C /usr/local clone -b v2.1.0 https://github.com/bats-core/bats-assert.git
 
-# Install xwin
-RUN wget --no-hsts -qO - "https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VERSION}/xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz" | tar -xzv -C /usr/local/bin --strip-components=1 "xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl/xwin"
-
-# Compile and install additional clang tools; often necessary as binary arm64 builds are lacking, or packages are out-of-date
-# Install ccache from source for a recent version
-RUN --mount=type=cache,target=/cache,sharing=locked \
- wget --no-hsts -qO - https://github.com/ccache/ccache/archive/refs/tags/v${CCACHE_VERSION}.tar.gz | tar xz -C /tmp \
- && CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=Off -DENABLE_DOCUMENTATION=Off -S /tmp/ccache-${CCACHE_VERSION} -B /tmp/ccache-${CCACHE_VERSION}/build \
- && cmake --build /tmp/ccache-${CCACHE_VERSION}/build --target install \
- && rm -rf /tmp/ccache-${CCACHE_VERSION}
+# Install xwin and ccache
+RUN wget --no-hsts -qO - "https://github.com/Jake-Shadle/xwin/releases/download/${XWIN_VERSION}/xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl.tar.gz" | tar -xzv -C /usr/local/bin --strip-components=1 "xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl/xwin" \
+ && wget --no-hsts -qO - "https://github.com/ccache/ccache/releases/download/v${CCACHE_VERSION}/ccache-${CCACHE_VERSION}-linux-$(uname -m).tar.xz" | tar -xJ -C /usr/local/bin --strip-components=1 "ccache-${CCACHE_VERSION}-linux-$(uname -m)/ccache"
 
 # Install include-what-you-use (iwyu) from source
 # hadolint ignore=DL3008


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This PR updates ccache to version 4.12, as per https://github.com/ccache/ccache/pull/1598 aarch64 binaries are also built and published as release artifacts. So we can consume from GitHub Releases instead of building ccache ourselves. 🎉 

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
