### PR TITLE
ci: remove upload documents from matrix job

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -90,16 +90,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
           REPOSITORY_NAME: ${{ github.event.repository.name }}
-      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
-        with:
-          pattern: documents
-      - name: Upload documents to release
-        run: |
-          set -Eeuo pipefail
-          gh release upload "${REF_NAME}" ./*.pdf
-        env:
-          GH_REPO: ${{ github.repository }}
-          GH_TOKEN: ${{ github.token }}
       - name: Update package details in release
         run: |
           set -Eeuo pipefail
@@ -109,5 +99,21 @@ jobs:
           gh release edit "${REF_NAME}" --notes "${UPDATED_NOTES}"
         env:
           DIGEST: ${{ steps.inspect-manifest.outputs.digest }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+  upload-documents:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    needs: [build-push-test]
+    steps:
+      - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          pattern: documents
+      - name: Upload documents to release
+        run: |
+          set -Eeuo pipefail
+          gh release upload "${REF_NAME}" ./*.pdf
+        env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

Document uploads as part of a release have been wrongfully added to the matrix job that runs for every container. Documents should only be uploaded once, so moved document upload to a separate job.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
