### PR TITLE
fix: attestation verification for repos that re-use amp-devcontainer workflows

### DIFF
--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -249,7 +249,7 @@ jobs:
           show-summary: false
           push-to-registry: true
       - name: Verify attestation
-        run: gh attestation verify --repo "${GH_REPO}" "oci://${FULLY_QUALIFIED_IMAGE_NAME}@${DIGEST}"
+        run: gh attestation verify --repo "${GH_REPO}" --signer-workflow philips-software/amp-devcontainer/.github/workflows/wc-build-push.yml "oci://${FULLY_QUALIFIED_IMAGE_NAME}@${DIGEST}"
         env:
           DIGEST: ${{ steps.inspect-manifest.outputs.digest }}
           FULLY_QUALIFIED_IMAGE_NAME: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request updates the attestation verification step in the `.github/workflows/wc-build-push.yml` workflow to improve security and traceability.

Security and attestation verification:

* The `Verify attestation` step now explicitly specifies the `--signer-workflow` parameter, referencing the `philips-software/amp-devcontainer/.github/workflows/wc-build-push.yml` workflow for signer verification. This ensures that attestations are only accepted from trusted workflows and enhances the provenance of built images.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
