### PR TITLE
ci: re-add document generation to release

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -120,6 +120,11 @@ jobs:
           DIGEST: ${{ steps.inspect-manifest.outputs.digest }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
+  generate-documents:
+    name: 📄 Documentation
+    uses: ./.github/workflows/wc-document-generation.yml
+    permissions:
+      contents: read
   upload-documents:
     name: 📄 Upload Documents
     runs-on: ubuntu-latest
@@ -128,7 +133,7 @@ jobs:
       # Please note that this is an overly broad scope, but GitHub does not
       # currently provide a more fine-grained permission for release modification.
       contents: write
-    needs: [build-push-test]
+    needs: [generate-documents]
     steps:
       - uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This PR fixes the broken document generation for releases after the recent workflow refactoring. During the release build no document were generated because of a missing step, and thus the publishing of documents failed.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
