### PR TITLE
chore(deps): bump ubuntu from `c35e29c` to `cd1dba6` in amp-devcontainer-base

### DIFF
--- a/.devcontainer/base/Dockerfile
+++ b/.devcontainer/base/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM ubuntu:24.04@sha256:c35e29c9450151419d9448b0fd75374fec4fff364a27f176fb458d472dfc9e54 AS extractor
+FROM ubuntu:24.04@sha256:cd1dba651b3080c3686ecf4e3c4220f026b521fb76978881737d24f200828b2b AS extractor
 
 ARG BATS_CORE_VERSION=1.12.0
 ARG BATS_SUPPORT_VERSION=0.3.0
@@ -20,7 +20,7 @@ RUN tar xzf /bats-core.tar.gz && mv bats-core-*/ bats-core \
  && tar xzf /bats-support.tar.gz && mv bats-support-*/ bats-support \
  && tar xzf /bats-assert.tar.gz && mv bats-assert-*/ bats-assert
 
-FROM ubuntu:24.04@sha256:c35e29c9450151419d9448b0fd75374fec4fff364a27f176fb458d472dfc9e54
+FROM ubuntu:24.04@sha256:cd1dba651b3080c3686ecf4e3c4220f026b521fb76978881737d24f200828b2b
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request updates the base Ubuntu image used in the `.devcontainer/base/Dockerfile` to a newer version. This change ensures the development container uses the latest security patches and system libraries.

Container base image update:

* Updated the Ubuntu image SHA256 digest for both the `extractor` stage and the main build stage in `.devcontainer/base/Dockerfile` to use the latest available version. [[1]](diffhunk://#diff-58e042c2666e91664436d720403d15e6cb5c939c131417c9a0bef9e6f7563f03L3-R3) [[2]](diffhunk://#diff-58e042c2666e91664436d720403d15e6cb5c939c131417c9a0bef9e6f7563f03L23-R23)

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
