### PR TITLE
chore: verify xwin checksum

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -1,5 +1,5 @@
-# hadolint global ignore=DL3006
 # syntax=docker/dockerfile:1
+# hadolint global ignore=DL3006
 
 ARG BASE_IMAGE=ghcr.io/philips-software/amp-devcontainer-base:edge
 ARG XWIN_VERSION=0.7.0


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request refactors the installation process for the `xwin` tool in the `.devcontainer/cpp/Dockerfile` to improve cross-architecture support and caching efficiency. The changes introduce multi-stage builds to download and extract the correct `xwin` binary for either AMD64 or ARM64 architectures, and move the installation logic into an earlier build stage. This also removes the previous direct download and extraction of `xwin` in the main image build step.

Key improvements to multi-architecture support and build efficiency:

* Added multi-stage build steps (`downloader-amd64`, `downloader-arm64`, `extractor`) to download and extract the appropriate `xwin` binary for the target architecture, using checksums for verification. (.devcontainer/cpp/Dockerfile)
* Moved the installation of `xwin` to an earlier stage and now copy the extracted binary into the final image, instead of downloading and extracting it during the main build step. (.devcontainer/cpp/Dockerfile)
* Removed the previous combined installation step for `xwin` and `ccache`, now only installing `ccache` directly in the final image. (.devcontainer/cpp/Dockerfile)

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
