### PR TITLE
ci: switch some workflows to ubuntu-slim

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,7 +69,7 @@ jobs:
 
   publish-test-results:
     name: 📊 Publish Test Results
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       checks: write # is needed by EnricoMi/publish-unit-test-result-action to add a check run with test results
       pull-requests: write # is needed by EnricoMi/publish-unit-test-result-action to annotate PRs

--- a/.github/workflows/image-cleanup.yml
+++ b/.github/workflows/image-cleanup.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   cleanup-images:
     name: 🧹 Clean Images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       packages: write # is needed by dataaxiom/ghcr-cleanup-action to delete untagged and orphaned images
     steps:

--- a/.github/workflows/issue-cleanup.yml
+++ b/.github/workflows/issue-cleanup.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   close-issues:
     name: ♻️ Close Stale Issues & PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       issues: write # is needed by actions/stale to close/comment on issues
       pull-requests: write # is needed by actions/stale to close/comment on PRs

--- a/.github/workflows/issue-creation-tool-versions.yml
+++ b/.github/workflows/issue-creation-tool-versions.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   create-issue:
     name: Create tool version evaluation issue
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read # is needed to checkout the repository
       issues: write # is needed by gh cli to create/close/pin/unpin issues

--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   ossf-scorecard:
     name: 🛡️ OpenSSF Scorecard
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       security-events: write # is needed by github/codeql-action/upload-sarif to upload sarif files

--- a/.github/workflows/pr-conventional-title.yml
+++ b/.github/workflows/pr-conventional-title.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   validate-pr-title:
     name: ✅ Validate PR Title
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write # is needed by marocchino/sticky-pull-request-comment to post comments on PRs
     steps:

--- a/.github/workflows/pr-image-cleanup.yml
+++ b/.github/workflows/pr-image-cleanup.yml
@@ -10,7 +10,7 @@ permissions: {}
 jobs:
   delete-images:
     name: 🗑️ Delete PR Images
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       packages: write # is needed by dataaxiom/ghcr-cleanup-action to delete images
     steps:
@@ -21,11 +21,11 @@ jobs:
       - uses: dataaxiom/ghcr-cleanup-action@cd0cdb900b5dbf3a6f2cc869f0dbb0b8211f50c4 # v1.0.16
         with:
           delete-tags: pr-${{ github.event.pull_request.number }}
-          packages: amp-devcontainer,amp-devcontainer-cpp,amp-devcontainer-rust
+          packages: amp-devcontainer,amp-devcontainer-base,amp-devcontainer-cpp,amp-devcontainer-rust
 
   cleanup-cache:
     name: 🧹 Cleanup Cache
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       actions: write # is needed to delete workflow run caches
     steps:

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write # is needed by philips-software/pull-request-report-action to post the report as a comment on the PR
       repository-projects: read # is needed by philips-software/pull-request-report-action to fetch project information
       actions: read # is needed by philips-software/pull-request-report-action to fetch workflow run information
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: step-security/harden-runner@20cf305ff2072d973412fa9b1e3a4f227bda3c76 # v2.14.0
         with:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,7 @@ permissions: {}
 jobs:
   create-release:
     name: 🚀 Create Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:

--- a/.github/workflows/wc-document-generation.yml
+++ b/.github/workflows/wc-document-generation.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   generate-documents:
     name: Generate Documents
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request updates several GitHub Actions workflow files to use the `ubuntu-slim` runner instead of `ubuntu-latest`. Additionally, it expands the list of packages cleaned up in the PR image cleanup workflow. These changes help improve resource efficiency and ensure more targeted maintenance of development resources.

**Workflow runner improvements:**

* Changed the `runs-on` field from `ubuntu-latest` to `ubuntu-slim` in the following workflows for more lightweight and efficient CI/CD runs:
  - `.github/workflows/continuous-integration.yml`
  - `.github/workflows/image-cleanup.yml`
  - `.github/workflows/issue-cleanup.yml`
  - `.github/workflows/issue-creation-tool-versions.yml`
  - `.github/workflows/ossf-scorecard.yml`
  - `.github/workflows/pr-conventional-title.yml`
  - `.github/workflows/pr-image-cleanup.yml` [[1]](diffhunk://#diff-59f982b798eff216a58f0f295dfbf0fdca2d2be36d8904234872495bb53a72c6L13-R13) [[2]](diffhunk://#diff-59f982b798eff216a58f0f295dfbf0fdca2d2be36d8904234872495bb53a72c6L24-R28)
  - `.github/workflows/pr-report.yml`
  - `.github/workflows/release-please.yml`
  - `.github/workflows/wc-document-generation.yml`

**PR image cleanup enhancements:**

* Added `amp-devcontainer-base` to the list of packages cleaned up by the `ghcr-cleanup-action` in `.github/workflows/pr-image-cleanup.yml`, ensuring more comprehensive image cleanup.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
