### PR TITLE
chore: verify signatures for apt keys

### DIFF
--- a/.devcontainer/base/Dockerfile
+++ b/.devcontainer/base/Dockerfile
@@ -35,6 +35,8 @@ RUN --mount=type=bind,source=.devcontainer/base/apt-requirements.json,target=/tm
     --mount=type=cache,target=/var/log,sharing=locked \
     --mount=from=extractor,target=/src <<EOF
 
+   set -e
+
    # Install the base system with all tool dependencies
    apt-get update && apt-get install -y --no-install-recommends jq
    jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/apt-requirements.json | \

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -32,6 +32,11 @@ ADD --checksum=sha256:b85cd1e0c94f249338b02a6e54b380154a5af6b5dd754121b15722125a
 # trivy:ignore:AVD-DS-0001
 FROM downloader-${TARGETARCH} AS downloader
 
+ADD --checksum=sha256:ce6eee4130298f79b0e0f09a89f93c1bc711cd68e7e3182d37c8e96c5227e2f0 \
+ https://apt.llvm.org/llvm-snapshot.gpg.key /llvm.gpg.key
+ADD --checksum=sha256:db2938ce5fd422f2db7a07508452772c945135d99274004c462190c323fefcf1 \
+ https://dl.cloudsmith.io/public/mull-project/mull-stable/gpg.41DB35380DE6BD6F.key /mull.gpg.key
+
 # Extractor stage using target architecture specific downloader
 FROM ${BASE_IMAGE} AS extractor
 
@@ -41,8 +46,11 @@ ARG XWIN_VERSION
 WORKDIR /
 
 RUN --mount=from=downloader,target=/dl <<EOF
+    set -e
     tar xJf /dl/ccache.tar.xz --strip-components=1 "ccache-${CCACHE_VERSION}-linux-$(uname -m)/ccache"
     tar xzf /dl/xwin.tar.gz --strip-components=1 "xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl/xwin"
+    cp /dl/llvm.gpg.key /llvm.gpg.key
+    cp /dl/mull.gpg.key /mull.gpg.key
 EOF
 
 # Final development container image
@@ -70,6 +78,7 @@ ENV CCACHE_DIR=/cache/.ccache \
 # Install the base system with all tool dependencies
 # hadolint ignore=DL3008
 RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target=/tmp/apt-requirements-base.json \
+    --mount=type=bind,source=.devcontainer/cpp/apt-requirements-clang.json,target=/tmp/apt-requirements-clang.json \
     --mount=type=bind,source=.devcontainer/cpp/requirements.txt,target=/tmp/requirements.txt \
     --mount=type=cache,target=/cache,sharing=locked \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -77,9 +86,10 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     --mount=type=cache,target=/var/log,sharing=locked \
     --mount=from=extractor,target=/src <<EOF
 
+    set -e
+
     # Install the base system with all tool dependencies
-    apt-get update && \
-    jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/apt-requirements-base.json | \
+    apt-get update && jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/apt-requirements-base.json | \
         xargs apt-get install -y --no-install-recommends
 
     # Install some tools via pip to get more recent versions, clean up afterwards
@@ -90,21 +100,18 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     # Install ccache and xwin
     cp /src/ccache /usr/local/bin/ccache
     cp /src/xwin /usr/local/bin/xwin
-EOF
 
-# Install clang toolchain and mull mutation testing framework
-RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-clang.json,target=/tmp/apt-requirements-clang.json \
-    --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    --mount=type=cache,target=/var/log,sharing=locked \
- wget --no-hsts -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg \
- && wget --no-hsts -qO - https://dl.cloudsmith.io/public/mull-project/mull-stable/gpg.41DB35380DE6BD6F.key | gpg --dearmor -o /usr/share/keyrings/mull-project-mull-stable-archive-keyring.gpg \
- && UBUNTU_CODENAME=$(grep '^UBUNTU_CODENAME=' /etc/os-release | cut -d= -f2) \
- && echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-${CLANG_VERSION} main" | tee /etc/apt/sources.list.d/llvm.list > /dev/null \
- && echo "deb [signed-by=/usr/share/keyrings/mull-project-mull-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/mull-project/mull-stable/deb/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/mull-project-mull-stable.list > /dev/null \
- && echo -e 'Package: *\nPin: origin "apt.llvm.org"\nPin-Priority: 1000' > /etc/apt/preferences \
- && apt-get update \
- && jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/apt-requirements-clang.json | xargs apt-get install -y --no-install-recommends
+    # Install clang toolchain and mull mutation testing framework
+    cat /src/llvm.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
+    cat /src/mull.gpg.key | gpg --dearmor -o /usr/share/keyrings/mull-project-mull-stable-archive-keyring.gpg
+
+    UBUNTU_CODENAME=$(grep '^UBUNTU_CODENAME=' /etc/os-release | cut -d= -f2)
+    echo "deb [signed-by=/usr/share/keyrings/llvm-snapshot-keyring.gpg] http://apt.llvm.org/${UBUNTU_CODENAME}/ llvm-toolchain-${UBUNTU_CODENAME}-${CLANG_VERSION} main" | tee /etc/apt/sources.list.d/llvm-snapshot.list > /dev/null
+    echo "deb [signed-by=/usr/share/keyrings/mull-project-mull-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/mull-project/mull-stable/deb/ubuntu ${UBUNTU_CODENAME} main" | tee /etc/apt/sources.list.d/mull-project-mull-stable.list > /dev/null
+    echo -e 'Package: *\nPin: origin "apt.llvm.org"\nPin-Priority: 1000' > /etc/apt/preferences
+    apt-get update && jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/apt-requirements-clang.json | \
+        xargs apt-get install -y --no-install-recommends
+EOF
 
 # Install arm-gcc toolchain
 RUN mkdir /opt/gcc-arm-none-eabi \


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request updates the development container Dockerfiles for C++ and base images to improve reliability and reproducibility of package installation, especially for the Clang and Mull toolchains. The changes focus on prefetching GPG keys, restructuring how dependencies are mounted and installed, and enhancing build script robustness.

Key improvements include:

**Reliability and Security Improvements:**

* GPG keys for LLVM and Mull repositories are now downloaded and added to the image in a dedicated build stage (`downloader`), rather than being fetched at build time with `wget`. This ensures reproducible builds and avoids network-related failures during subsequent build stages. [[1]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R35-R39) [[2]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R49-R53)
* The installation of APT requirements for both base and Clang toolchains now uses `set -e` to ensure the build stops on errors, improving robustness. [[1]](diffhunk://#diff-58e042c2666e91664436d720403d15e6cb5c939c131417c9a0bef9e6f7563f03R38-R39) [[2]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R49-R53) [[3]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R81-R92)

**Build Process Refactoring:**

* The Clang and Mull GPG keys are copied from the `downloader` stage to the build context and then installed from local files, replacing the previous `wget | gpg --dearmor` approach. This also removes the need for live downloads during the build. [[1]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R49-R53) [[2]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L93-R114)
* The Clang toolchain and Mull repository setup is consolidated into a single multi-line RUN block, using the pre-fetched keys and improving clarity.

**Dependency Management:**

* The Clang-specific APT requirements file is now mounted together with the base requirements, streamlining the installation process and making the Dockerfile more maintainable.

These changes collectively make the container builds more deterministic, secure, and easier to maintain.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
