### PR TITLE
chore: verify checksum for arm-gcc toolchain

### DIFF
--- a/.devcontainer/base/Dockerfile
+++ b/.devcontainer/base/Dockerfile
@@ -26,7 +26,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 HEALTHCHECK NONE
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # hadolint ignore=DL3008
 RUN --mount=type=bind,source=.devcontainer/base/apt-requirements.json,target=/tmp/apt-requirements.json \
@@ -34,8 +34,6 @@ RUN --mount=type=bind,source=.devcontainer/base/apt-requirements.json,target=/tm
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/var/log,sharing=locked \
     --mount=from=extractor,target=/src <<EOF
-
-   set -Eeuo pipefail
 
    # Install the base system with all tool dependencies
    apt-get update && apt-get install -y --no-install-recommends jq

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -78,7 +78,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 HEALTHCHECK NONE
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
 
 # Set default environment options
 ENV CCACHE_DIR=/cache/.ccache \
@@ -99,8 +99,6 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     --mount=type=cache,target=/var/log,sharing=locked \
     --mount=from=extractor,target=/src <<EOF
-
-    set -Eeuo pipefail
 
     # Install the base system with all tool dependencies
     apt-get update && jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/apt-requirements-base.json | \
@@ -127,7 +125,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
         xargs apt-get install -y --no-install-recommends
 
     # Install arm-gcc toolchain
-    cp -r /src/arm-gnu-toolchain-*-arm-none-eabi /opt/gcc-arm-none-eabi
+    cp -a /src/arm-gnu-toolchain-*-arm-none-eabi /opt/gcc-arm-none-eabi
 EOF
 
 # Install include-what-you-use (iwyu) from source


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request updates the devcontainer Dockerfiles to improve reliability and security of the build process, and refactors the installation of the ARM GNU toolchain. The most important changes are grouped below:

**Shell safety and reliability improvements:**

* Changed shell invocation in various Dockerfile steps to use `set -Eeuo pipefail`, which ensures stricter error handling and catches more issues during builds. This change was applied to `.devcontainer/base/Dockerfile` and `.devcontainer/cpp/Dockerfile` steps. [[1]](diffhunk://#diff-58e042c2666e91664436d720403d15e6cb5c939c131417c9a0bef9e6f7563f03L38-R38) [[2]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L89-R103)

* Updated the shell used in the `extractor` stage of `.devcontainer/cpp/Dockerfile` to `/bin/bash -Eeuo pipefail -c`, further improving script robustness.

**ARM GNU toolchain installation refactor:**

* Moved the download and extraction of the ARM GNU toolchain from a direct install in the main stage to the `extractor` stage. The new process downloads the toolchain, verifies its SHA256 checksum based on architecture, and extracts it (excluding unnecessary files), then copies it into the final image. [[1]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R46-R63) [[2]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L114-R131)

* Removed the previous inline download-and-extract command for the ARM GNU toolchain in favor of copying the pre-extracted toolchain directory from the `extractor` stage.

These changes collectively make the build process more robust and secure, and streamline the installation of critical toolchain dependencies.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
