### PR TITLE
fix: update apt.llvm.org gpg key checksum

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -32,7 +32,7 @@ ADD --checksum=sha256:b85cd1e0c94f249338b02a6e54b380154a5af6b5dd754121b15722125a
 # trivy:ignore:AVD-DS-0001
 FROM downloader-${TARGETARCH} AS downloader
 
-ADD --checksum=sha256:ce6eee4130298f79b0e0f09a89f93c1bc711cd68e7e3182d37c8e96c5227e2f0 \
+ADD --checksum=sha256:8b2a587ffd672c4687e7581dad4b2f6c1bb2ad6b480cd9771ba2ff48e0b8c75d \
  https://apt.llvm.org/llvm-snapshot.gpg.key /llvm.gpg.key
 ADD --checksum=sha256:db2938ce5fd422f2db7a07508452772c945135d99274004c462190c323fefcf1 \
  https://dl.cloudsmith.io/public/mull-project/mull-stable/gpg.41DB35380DE6BD6F.key /mull.gpg.key


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

According to [apt.llvm.org](https://apt.llvm.org) the GPG key was updated to support SHA-512, as it was previously using SHA-1 that is deemed compromised/insecure as of 01-feb-2026.

See https://github.com/llvm/llvm-project/issues/179147 and https://github.com/llvm/llvm-project/issues/179148 and the attached screenshot.

<img width="1146" height="892" alt="image" src="https://github.com/user-attachments/assets/a2900c53-a183-49e9-b093-f73682137076" />

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
