### PR TITLE
fix: add required permission to release workflow

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -43,6 +43,7 @@ jobs:
       TEST_GITHUB_TOTP_SECRET: ${{ secrets.TEST_GITHUB_TOTP_SECRET }}
     permissions:
       actions: read # is needed by anchore/sbom-action to find workflow artifacts when attaching release assets
+      artifact-metadata: write # is needed by actions/attest-build-provenance to write artifact metadata
       attestations: write # is needed by actions/attest-build-provenance to push attestations
       contents: write # is needed by anchore/sbom-action for artifact uploads
       id-token: write # is needed by actions/attest-build-provenance to obtain an OIDC token


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request introduces a small but important update to the GitHub Actions workflow permissions. The change grants the workflow permission to write artifact metadata, which is required for build provenance attestation.

* Updated `.github/workflows/release-build.yml` to add `artifact-metadata: write` permission, enabling `actions/attest-build-provenance` to write artifact metadata.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
