### PR TITLE
feat: switch container compression algorithm to zstd

### DIFF
--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -129,7 +129,7 @@ jobs:
             ${{ steps.devcontainer-metadata.outputs.label }}
           annotations: ${{ steps.metadata.outputs.annotations }}
           sbom: true
-          outputs: type=image,compression=zstd,force-compression=true,push-by-digest=true,name-canonical=true
+          outputs: type=image,compression=zstd,compression-level=9,force-compression=true,push-by-digest=true,name-canonical=true
       - name: Export digest
         run: |
           set -Eeuo pipefail


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request makes a small update to the build workflow by enabling image compression with zstd when building and pushing container images. This change helps reduce image size and potentially speeds up image transfers.

* Build workflow improvement:
  * [`.github/workflows/wc-build-push.yml`](diffhunk://#diff-2a36c16587df302d628f7fa10f67cd05731fd199924c74e067618126cf8e7d8cL132-R132): Added `compression=zstd` and `force-compression=true` to the `outputs` parameter for image builds, enabling zstd compression for pushed images.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
