### PR TITLE
chore(deps): update ccache to v4.13.1 in amp-devcontainer-cpp

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -2,6 +2,9 @@
 # hadolint global ignore=DL3006
 
 ARG BASE_IMAGE=ghcr.io/philips-software/amp-devcontainer-base:edge
+# Public minisign key for verifying ccache releases,
+# taken from https://ccache.dev/minisign.pub
+ARG CCACHE_MINISIGN_PUBKEY=RWQX7yXbBedVfI4PNx6FLdFXu9GHUFsr28s4BVGxm4BeybtnX3P06saF
 ARG CCACHE_VERSION=4.13.1
 ARG XWIN_VERSION=0.8.0
 
@@ -44,6 +47,7 @@ ADD --checksum=sha256:db2938ce5fd422f2db7a07508452772c945135d99274004c462190c323
 # Extractor stage using target architecture specific downloader
 FROM ${BASE_IMAGE} AS extractor
 
+ARG CCACHE_MINISIGN_PUBKEY
 ARG CCACHE_VERSION
 ARG XWIN_VERSION
 
@@ -69,7 +73,7 @@ RUN --mount=from=downloader,target=/dl \
     wget --no-hsts -qO "${ARM_GNU_TOOLCHAIN_TAR}" "${ARM_GNU_TOOLCHAIN_URL}"
     echo "${ARM_GNU_TOOLCHAIN_SHA256}  ${ARM_GNU_TOOLCHAIN_TAR}" | sha256sum -c -
 
-    minisign -P RWQX7yXbBedVfI4PNx6FLdFXu9GHUFsr28s4BVGxm4BeybtnX3P06saF -Vm /dl/ccache.tar.xz
+    minisign -P "${CCACHE_MINISIGN_PUBKEY}" -Vm /dl/ccache.tar.xz
 
     tar xJf "${ARM_GNU_TOOLCHAIN_TAR}" --exclude="*arm-none-eabi-gdb*" --exclude="share"
     tar xJf /dl/ccache.tar.xz --strip-components=1 "ccache-${CCACHE_VERSION}-linux-$(uname -m)-glibc/ccache"


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request updates the C++ development container's Dockerfile to improve security and reliability when installing `ccache`, as well as updating to a newer version. The most important changes are grouped below:

**ccache version update and verification improvements:**

* Updated the `CCACHE_VERSION` from `4.12.2` to `4.13.1` to use the latest release.
* Added download and checksum verification for the `.minisig` signature files for both x86_64 and aarch64 `ccache` binaries, enhancing the authenticity verification of the downloaded binaries. [[1]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L14-R17) [[2]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L25-R30)
* Installed `minisign` and added a step to verify the downloaded `ccache` tarball using its signature before extracting, improving supply chain security. [[1]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L50-R58) [[2]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R71-R72)

**Build performance:**

* Added persistent caching for APT package lists to speed up repeated builds.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
