### PR TITLE
fix: resolve sonarqube security findings

### DIFF
--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -49,7 +49,7 @@ ADD --checksum=sha256:8b2a587ffd672c4687e7581dad4b2f6c1bb2ad6b480cd9771ba2ff48e0
  https://apt.llvm.org/llvm-snapshot.gpg.key /llvm.gpg.key
 ADD --checksum=sha256:db2938ce5fd422f2db7a07508452772c945135d99274004c462190c323fefcf1 \
  https://dl.cloudsmith.io/public/mull-project/mull-stable/gpg.41DB35380DE6BD6F.key /mull.gpg.key
-ADD --checksum=sha256:1c40fc102ce9625d7de7eb14f541cab30cc3138dca627f0b0ec40293ce6c2934
+ADD --checksum=sha256:1c40fc102ce9625d7de7eb14f541cab30cc3138dca627f0b0ec40293ce6c2934 \
  https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake /CPM.cmake
 
 # Extractor stage using target architecture specific downloader

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=from=downloader,target=/dl \
             ARM_GNU_TOOLCHAIN_SHA256="d061559d814b205ed30c5b7c577c03317ec447ca51cd5a159d26b12a5bbeb20c"
         fi
 
-        wget --no-hsts --https-only -qO "${ARM_GNU_TOOLCHAIN_TAR}" "${ARM_GNU_TOOLCHAIN_URL}"
+        wget --no-hsts -qO "${ARM_GNU_TOOLCHAIN_TAR}" "${ARM_GNU_TOOLCHAIN_URL}"
         echo "${ARM_GNU_TOOLCHAIN_SHA256}  ${ARM_GNU_TOOLCHAIN_TAR}" | sha256sum -c -
 
         tar xJf "${ARM_GNU_TOOLCHAIN_TAR}" --exclude="*arm-none-eabi-gdb*" --exclude="share"
@@ -136,8 +136,8 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     rm -rf "$(pip cache dir)"
 
     # Install ccache and xwin
-    cp /src/ccache /usr/local/bin/ccache
-    cp /src/xwin /usr/local/bin/xwin
+    install -m 0755 /src/ccache /usr/local/bin/ccache
+    install -m 0755 /src/xwin /usr/local/bin/xwin
 
     # Install clang toolchain and mull mutation testing framework
     cat /src/llvm.gpg.key | gpg --dearmor -o /usr/share/keyrings/llvm-snapshot-keyring.gpg
@@ -157,7 +157,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
 
     # Install include-what-you-use (iwyu) from source
     apt-get update && apt-get install -y --no-install-recommends "libclang-${CLANG_VERSION}-dev" "llvm-${CLANG_VERSION}-dev"
-    wget --no-hsts --https-only -qO - "https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz" | tar xz -C /tmp
+    wget --no-hsts -qO - "https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz" | tar xz -C /tmp
     CC=clang CXX=clang++ cmake -S "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}" -B "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build"
     cmake --build "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build" --target install
     rm -rf "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}"
@@ -189,7 +189,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     # CMake module (not an ELF binary), so it cannot carry a `.note.package` ELF
     # section and Syft has no cataloger for standalone `.cmake` files. Its version is
     # pinned and tracked via the CPM_VERSION build argument above.
-    wget --no-hsts --https-only -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake"
+    wget --no-hsts -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake"
     conan profile detect
     echo -e "\n[conf]\ntools.cmake.cmaketoolchain:generator=Ninja" >> "$(conan profile path default)"
 

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -156,12 +156,12 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     fi
 
     # Install include-what-you-use (iwyu) from source
-    apt-get update && apt-get install -y --no-install-recommends libclang-${CLANG_VERSION}-dev llvm-${CLANG_VERSION}-dev
-    wget --no-hsts --https-only -qO - https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz | tar xz -C /tmp
-    CC=clang CXX=clang++ cmake -S /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION} -B /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build
-    cmake --build /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build --target install
-    rm -rf /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}
-    apt-get purge -y libclang-${CLANG_VERSION}-dev llvm-${CLANG_VERSION}-dev
+    apt-get update && apt-get install -y --no-install-recommends "libclang-${CLANG_VERSION}-dev" "llvm-${CLANG_VERSION}-dev"
+    wget --no-hsts --https-only -qO - "https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz" | tar xz -C /tmp
+    CC=clang CXX=clang++ cmake -S "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}" -B "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build"
+    cmake --build "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build" --target install
+    rm -rf "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}"
+    apt-get purge -y "libclang-${CLANG_VERSION}-dev" "llvm-${CLANG_VERSION}-dev"
     apt-get autoremove -y
     apt-get clean
 
@@ -172,9 +172,9 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     update-alternatives --install /usr/bin/cc cc /usr/bin/gcc-15 10 \
                         --slave /usr/bin/c++ c++ /usr/bin/g++-15
     update-alternatives --install /usr/bin/iwyu iwyu /usr/local/bin/include-what-you-use 10
-    update-alternatives --install /usr/bin/mull-runner mull-runner /usr/bin/mull-runner-${CLANG_VERSION} 10 \
-                        --slave /usr/bin/mull-reporter mull-reporter /usr/bin/mull-reporter-${CLANG_VERSION} \
-                        --slave /usr/lib/mull-ir-frontend mull-ir-frontend /usr/lib/mull-ir-frontend-${CLANG_VERSION}
+    update-alternatives --install /usr/bin/mull-runner mull-runner "/usr/bin/mull-runner-${CLANG_VERSION}" 10 \
+                        --slave /usr/bin/mull-reporter mull-reporter "/usr/bin/mull-reporter-${CLANG_VERSION}" \
+                        --slave /usr/lib/mull-ir-frontend mull-ir-frontend "/usr/lib/mull-ir-frontend-${CLANG_VERSION}"
     update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
     # Add a dummy compile_commands.json file to the default location so that tools like SonarLint and Clangd can find it.
@@ -189,7 +189,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     # CMake module (not an ELF binary), so it cannot carry a `.note.package` ELF
     # section and Syft has no cataloger for standalone `.cmake` files. Its version is
     # pinned and tracked via the CPM_VERSION build argument above.
-    wget --no-hsts --https-only -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake
+    wget --no-hsts --https-only -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake"
     conan profile detect
     echo -e "\n[conf]\ntools.cmake.cmaketoolchain:generator=Ninja" >> "$(conan profile path default)"
 

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=from=downloader,target=/dl \
             ARM_GNU_TOOLCHAIN_SHA256="d061559d814b205ed30c5b7c577c03317ec447ca51cd5a159d26b12a5bbeb20c"
         fi
 
-        wget --no-hsts --max-redirect=0 -qO "${ARM_GNU_TOOLCHAIN_TAR}" "${ARM_GNU_TOOLCHAIN_URL}"
+        wget --no-hsts --https-only -qO "${ARM_GNU_TOOLCHAIN_TAR}" "${ARM_GNU_TOOLCHAIN_URL}"
         echo "${ARM_GNU_TOOLCHAIN_SHA256}  ${ARM_GNU_TOOLCHAIN_TAR}" | sha256sum -c -
 
         tar xJf "${ARM_GNU_TOOLCHAIN_TAR}" --exclude="*arm-none-eabi-gdb*" --exclude="share"
@@ -189,7 +189,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     # CMake module (not an ELF binary), so it cannot carry a `.note.package` ELF
     # section and Syft has no cataloger for standalone `.cmake` files. Its version is
     # pinned and tracked via the CPM_VERSION build argument above.
-    wget --no-hsts  --max-redirect=0 -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake
+    wget --no-hsts --https-only -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake
     conan profile detect
     echo -e "\n[conf]\ntools.cmake.cmaketoolchain:generator=Ninja" >> "$(conan profile path default)"
 

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -76,7 +76,7 @@ RUN --mount=from=downloader,target=/dl \
             ARM_GNU_TOOLCHAIN_SHA256="d061559d814b205ed30c5b7c577c03317ec447ca51cd5a159d26b12a5bbeb20c"
         fi
 
-        wget --no-hsts -qO "${ARM_GNU_TOOLCHAIN_TAR}" "${ARM_GNU_TOOLCHAIN_URL}"
+        wget --no-hsts --max-redirect=0 -qO "${ARM_GNU_TOOLCHAIN_TAR}" "${ARM_GNU_TOOLCHAIN_URL}"
         echo "${ARM_GNU_TOOLCHAIN_SHA256}  ${ARM_GNU_TOOLCHAIN_TAR}" | sha256sum -c -
 
         tar xJf "${ARM_GNU_TOOLCHAIN_TAR}" --exclude="*arm-none-eabi-gdb*" --exclude="share"
@@ -157,7 +157,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
 
     # Install include-what-you-use (iwyu) from source
     apt-get update && apt-get install -y --no-install-recommends libclang-${CLANG_VERSION}-dev llvm-${CLANG_VERSION}-dev
-    wget --no-hsts -qO - https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz | tar xz -C /tmp
+    wget --no-hsts --max-redirect=0 -qO - https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz | tar xz -C /tmp
     CC=clang CXX=clang++ cmake -S /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION} -B /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build
     cmake --build /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build --target install
     rm -rf /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}
@@ -189,7 +189,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     # CMake module (not an ELF binary), so it cannot carry a `.note.package` ELF
     # section and Syft has no cataloger for standalone `.cmake` files. Its version is
     # pinned and tracked via the CPM_VERSION build argument above.
-    wget --no-hsts -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake
+    wget --no-hsts  --max-redirect=0 -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake
     conan profile detect
     echo -e "\n[conf]\ntools.cmake.cmaketoolchain:generator=Ninja" >> "$(conan profile path default)"
 

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -157,7 +157,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
 
     # Install include-what-you-use (iwyu) from source
     apt-get update && apt-get install -y --no-install-recommends libclang-${CLANG_VERSION}-dev llvm-${CLANG_VERSION}-dev
-    wget --no-hsts --max-redirect=0 -qO - https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz | tar xz -C /tmp
+    wget --no-hsts --https-only -qO - https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz | tar xz -C /tmp
     CC=clang CXX=clang++ cmake -S /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION} -B /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build
     cmake --build /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build --target install
     rm -rf /tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -7,6 +7,7 @@ ARG BASE_IMAGE=ghcr.io/philips-software/amp-devcontainer-base:edge
 ARG CCACHE_MINISIGN_PUBKEY=RWQX7yXbBedVfI4PNx6FLdFXu9GHUFsr28s4BVGxm4BeybtnX3P06saF
 ARG CCACHE_VERSION=4.13.1
 ARG CPM_VERSION=0.43.1
+ARG INCLUDE_WHAT_YOU_USE_VERSION=0.26
 ARG XWIN_VERSION=0.8.0
 # Whether or not to build the embedded flavor of this container
 ARG BUILD_EMBEDDED_FLAVOR=false
@@ -44,6 +45,7 @@ ADD --checksum=sha256:fe106caefbb316664d73fd03166c28c09e580bb2a3ad65b4d50c51c673
 FROM downloader-${TARGETARCH} AS downloader
 
 ARG CPM_VERSION
+ARG INCLUDE_WHAT_YOU_USE_VERSION
 
 ADD --checksum=sha256:8b2a587ffd672c4687e7581dad4b2f6c1bb2ad6b480cd9771ba2ff48e0b8c75d \
  https://apt.llvm.org/llvm-snapshot.gpg.key /llvm.gpg.key
@@ -51,6 +53,8 @@ ADD --checksum=sha256:db2938ce5fd422f2db7a07508452772c945135d99274004c462190c323
  https://dl.cloudsmith.io/public/mull-project/mull-stable/gpg.41DB35380DE6BD6F.key /mull.gpg.key
 ADD --checksum=sha256:1c40fc102ce9625d7de7eb14f541cab30cc3138dca627f0b0ec40293ce6c2934 \
  https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake /CPM.cmake
+ADD --checksum=sha256:ca3f157a5e6bf293cfb2fea585b103ec87245d02eaee0b6ab832665e740016eb \
+  https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz /iwyu.tar.gz
 
 # Extractor stage using target architecture specific downloader
 FROM ${BASE_IMAGE} AS extractor
@@ -91,6 +95,7 @@ RUN --mount=from=downloader,target=/dl \
 
     tar xJf /dl/ccache.tar.xz --strip-components=1 "ccache-${CCACHE_VERSION}-linux-$(uname -m)-glibc/ccache"
     tar xzf /dl/xwin.tar.gz --strip-components=1 "xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl/xwin"
+    tar xzf /dl/iwyu.tar.gz
     cp /dl/CPM.cmake /CPM.cmake
     cp /dl/llvm.gpg.key /llvm.gpg.key
     cp /dl/mull.gpg.key /mull.gpg.key
@@ -100,9 +105,9 @@ EOF
 FROM ${BASE_IMAGE}
 
 ARG CLANG_VERSION=22
-ARG INCLUDE_WHAT_YOU_USE_VERSION=0.26
 ARG BUILD_EMBEDDED_FLAVOR
 ARG CCACHE_VERSION
+ARG INCLUDE_WHAT_YOU_USE_VERSION
 ARG XWIN_VERSION
 ARG ARM_GNU_TOOLCHAIN_VERSION
 
@@ -162,10 +167,9 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
 
     # Install include-what-you-use (iwyu) from source
     apt-get update && apt-get install -y --no-install-recommends "libclang-${CLANG_VERSION}-dev" "llvm-${CLANG_VERSION}-dev"
-    wget --no-hsts -qO - "https://github.com/include-what-you-use/include-what-you-use/archive/refs/tags/${INCLUDE_WHAT_YOU_USE_VERSION}.tar.gz" | tar xz -C /tmp
-    CC=clang CXX=clang++ cmake -S "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}" -B "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build"
-    cmake --build "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}/build" --target install
-    rm -rf "/tmp/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}"
+    CC=clang CXX=clang++ cmake -S "/src/include-what-you-use-${INCLUDE_WHAT_YOU_USE_VERSION}" -B "/tmp/include-what-you-use/build"
+    cmake --build "/tmp/include-what-you-use/build" --target install
+    rm -rf "/tmp/include-what-you-use"
     apt-get purge -y "libclang-${CLANG_VERSION}-dev" "llvm-${CLANG_VERSION}-dev"
     apt-get autoremove -y
     apt-get clean

--- a/.devcontainer/cpp/Dockerfile
+++ b/.devcontainer/cpp/Dockerfile
@@ -6,6 +6,7 @@ ARG BASE_IMAGE=ghcr.io/philips-software/amp-devcontainer-base:edge
 # taken from https://ccache.dev/minisign.pub
 ARG CCACHE_MINISIGN_PUBKEY=RWQX7yXbBedVfI4PNx6FLdFXu9GHUFsr28s4BVGxm4BeybtnX3P06saF
 ARG CCACHE_VERSION=4.13.1
+ARG CPM_VERSION=0.43.1
 ARG XWIN_VERSION=0.8.0
 # Whether or not to build the embedded flavor of this container
 ARG BUILD_EMBEDDED_FLAVOR=false
@@ -42,10 +43,14 @@ ADD --checksum=sha256:fe106caefbb316664d73fd03166c28c09e580bb2a3ad65b4d50c51c673
 # trivy:ignore:AVD-DS-0001
 FROM downloader-${TARGETARCH} AS downloader
 
+ARG CPM_VERSION
+
 ADD --checksum=sha256:8b2a587ffd672c4687e7581dad4b2f6c1bb2ad6b480cd9771ba2ff48e0b8c75d \
  https://apt.llvm.org/llvm-snapshot.gpg.key /llvm.gpg.key
 ADD --checksum=sha256:db2938ce5fd422f2db7a07508452772c945135d99274004c462190c323fefcf1 \
  https://dl.cloudsmith.io/public/mull-project/mull-stable/gpg.41DB35380DE6BD6F.key /mull.gpg.key
+ADD --checksum=sha256:1c40fc102ce9625d7de7eb14f541cab30cc3138dca627f0b0ec40293ce6c2934
+ https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake /CPM.cmake
 
 # Extractor stage using target architecture specific downloader
 FROM ${BASE_IMAGE} AS extractor
@@ -86,6 +91,7 @@ RUN --mount=from=downloader,target=/dl \
 
     tar xJf /dl/ccache.tar.xz --strip-components=1 "ccache-${CCACHE_VERSION}-linux-$(uname -m)-glibc/ccache"
     tar xzf /dl/xwin.tar.gz --strip-components=1 "xwin-${XWIN_VERSION}-$(uname -m)-unknown-linux-musl/xwin"
+    cp /dl/CPM.cmake /CPM.cmake
     cp /dl/llvm.gpg.key /llvm.gpg.key
     cp /dl/mull.gpg.key /mull.gpg.key
 EOF
@@ -94,7 +100,6 @@ EOF
 FROM ${BASE_IMAGE}
 
 ARG CLANG_VERSION=22
-ARG CPM_VERSION=0.42.1
 ARG INCLUDE_WHAT_YOU_USE_VERSION=0.26
 ARG BUILD_EMBEDDED_FLAVOR
 ARG CCACHE_VERSION
@@ -189,7 +194,7 @@ RUN --mount=type=bind,source=.devcontainer/cpp/apt-requirements-base.json,target
     # CMake module (not an ELF binary), so it cannot carry a `.note.package` ELF
     # section and Syft has no cataloger for standalone `.cmake` files. Its version is
     # pinned and tracked via the CPM_VERSION build argument above.
-    wget --no-hsts -qP /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/ "https://github.com/cpm-cmake/CPM.cmake/releases/download/v${CPM_VERSION}/CPM.cmake"
+    cp /src/CPM.cmake /usr/local/lib/python*/dist-packages/cmake/data/share/cmake-*/Modules/
     conan profile detect
     echo -e "\n[conf]\ntools.cmake.cmaketoolchain:generator=Ninja" >> "$(conan profile path default)"
 

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -1,9 +1,10 @@
 # syntax=docker/dockerfile:1
 
 ARG BASE_IMAGE=ghcr.io/philips-software/amp-devcontainer-base:edge
-FROM ${BASE_IMAGE}
-
-ARG CARGO_BINSTALL_VERSION=1.17.9
+# Public minisign key for verifying ccache releases,
+# taken from https://ccache.dev/minisign.pub
+ARG CARGO_BINSTALL_MINISIGN_PUBKEY=RWRk4OqCLGFd42uTAec/I+038vQLmeZzCBOS40LLDVC6qW3SVuDsdcW0
+ARG CARGO_BINSTALL_VERSION=1.21.0
 ARG CARGO_BINUTILS_VERSION=0.3.6
 ARG CARGO_MUTANTS_VERSION=25.3.1
 ARG FLIP_LINK_VERSION=0.1.12
@@ -11,6 +12,51 @@ ARG PROBE_RS_TOOLS_VERSION=0.31.0
 ARG RUST_VERSION=1.94.1
 # Whether or not to build the embedded flavor of this container
 ARG BUILD_EMBEDDED_FLAVOR=false
+
+# Downloader stage for AMD64 architecture
+FROM scratch AS downloader-amd64
+
+ARG CARGO_BINSTALL_VERSION
+
+ADD --checksum=sha256:a753a83ea4c79a629790e003822d4e82bec5bf839120f1826969c2401bd9f559 \
+  https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz /cargo-binstall.tgz
+
+# Downloader stage for ARM64 architecture
+FROM scratch AS downloader-arm64
+
+ARG CARGO_BINSTALL_VERSION
+
+ADD --checksum=sha256:f70991d597655bc928444c0ac0dedcbd1d16a9e64d0b1ea544dde2cc710e25f6 \
+  https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz /cargo-binstall.tgz
+
+# Select downloader stage based on target architecture.
+# Linters don't recognize the TARGETARCH variable, so we ignore warnings here.
+# trivy:ignore:AVD-DS-0001
+FROM downloader-${TARGETARCH} AS downloader
+
+# Extractor stage using target architecture specific downloader
+FROM ${BASE_IMAGE} AS extractor
+
+ARG CARGO_BINSTALL_VERSION
+ARG CARGO_BINSTALL_MINISIGN_PUBKEY
+
+SHELL ["/bin/bash", "-Eeuo", "pipefail", "-c"]
+
+WORKDIR /
+
+# hadolint ignore=DL3008
+RUN --mount=from=downloader,target=/dl \
+    --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked <<EOF
+    apt-get update && apt-get install --no-install-recommends -y minisign
+
+    minisign -P "${CARGO_BINSTALL_MINISIGN_PUBKEY}" -Vm /dl/cargo-binstall.tgz
+
+    tar xzf /dl/cargo-binstall.tgz
+EOF
+
+# Final development container image
+FROM ${BASE_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -26,7 +72,8 @@ ENV BINSTALL_DISABLE_TELEMETRY=true \
 RUN --mount=type=bind,source=.devcontainer/rust/apt-requirements.json,target=/tmp/apt-requirements.json \
     --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
-    --mount=type=cache,target=/var/log,sharing=locked <<EOF
+    --mount=type=cache,target=/var/log,sharing=locked \
+    --mount=from=extractor,target=/src <<EOF
 
     # Install the base system with all tool dependencies
     apt-get update && jq -r 'to_entries | .[] | .key + "=" + .value' /tmp/apt-requirements.json | \
@@ -46,7 +93,7 @@ RUN --mount=type=bind,source=.devcontainer/rust/apt-requirements.json,target=/tm
         rustup target add thumbv7em-none-eabihf
     fi
 
-    wget --no-hsts --https-only -qO - "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz" | tar xz -C "/usr/bin"
+    install -m 0755 /src/cargo-binstall /usr/local/bin/cargo-binstall
     cargo-binstall -y --locked "cargo-binutils@${CARGO_BINUTILS_VERSION}" \
                                "cargo-mutants@${CARGO_MUTANTS_VERSION}"
 
@@ -61,7 +108,7 @@ RUN --mount=type=bind,source=.devcontainer/rust/apt-requirements.json,target=/tm
     # https://systemd.io/ELF_PACKAGE_METADATA/) so they are included in the SBOM
     # generated for the image. `add-sbom-note` is provided by the base image.
     add-sbom-note cargo-binstall "${CARGO_BINSTALL_VERSION}" "pkg:cargo/cargo-binstall@${CARGO_BINSTALL_VERSION}" \
-        /usr/bin/cargo-binstall
+        /usr/local/bin/cargo-binstall
     add-sbom-note cargo-binutils "${CARGO_BINUTILS_VERSION}" "pkg:cargo/cargo-binutils@${CARGO_BINUTILS_VERSION}" \
         "${CARGO_HOME}"/bin/cargo-{cov,nm,objcopy,profdata,readobj,size,strip}
     add-sbom-note cargo-mutants "${CARGO_MUTANTS_VERSION}" "pkg:cargo/cargo-mutants@${CARGO_MUTANTS_VERSION}" \

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -6,13 +6,6 @@ ARG BASE_IMAGE=ghcr.io/philips-software/amp-devcontainer-base:edge
 # taken from https://ccache.dev/minisign.pub
 ARG CARGO_BINSTALL_MINISIGN_PUBKEY=RWRk4OqCLGFd42uTAec/I+038vQLmeZzCBOS40LLDVC6qW3SVuDsdcW0
 ARG CARGO_BINSTALL_VERSION=1.21.0
-ARG CARGO_BINUTILS_VERSION=0.3.6
-ARG CARGO_MUTANTS_VERSION=25.3.1
-ARG FLIP_LINK_VERSION=0.1.12
-ARG PROBE_RS_TOOLS_VERSION=0.31.0
-ARG RUST_VERSION=1.94.1
-# Whether or not to build the embedded flavor of this container
-ARG BUILD_EMBEDDED_FLAVOR=false
 
 # Downloader stage for AMD64 architecture
 FROM scratch AS downloader-amd64
@@ -62,6 +55,15 @@ EOF
 
 # Final development container image
 FROM ${BASE_IMAGE}
+
+ARG CARGO_BINSTALL_VERSION
+ARG CARGO_BINUTILS_VERSION=0.3.6
+ARG CARGO_MUTANTS_VERSION=25.3.1
+ARG FLIP_LINK_VERSION=0.1.12
+ARG PROBE_RS_TOOLS_VERSION=0.31.0
+ARG RUST_VERSION=1.94.1
+# Whether or not to build the embedded flavor of this container
+ARG BUILD_EMBEDDED_FLAVOR=false
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -37,7 +37,7 @@ RUN --mount=type=bind,source=.devcontainer/rust/apt-requirements.json,target=/tm
 
     # Install rust
     rustup set profile minimal
-    rustup default ${RUST_VERSION}
+    rustup default "${RUST_VERSION}"
     rustup component add clippy llvm-tools rustfmt
 
     if [[ "${BUILD_EMBEDDED_FLAVOR}" == "true" ]]; then

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -46,7 +46,7 @@ RUN --mount=type=bind,source=.devcontainer/rust/apt-requirements.json,target=/tm
         rustup target add thumbv7em-none-eabihf
     fi
 
-    wget --no-hsts --max-redirect=0 -qO - "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz" | tar xz -C "/usr/bin"
+    wget --no-hsts --https-only -qO - "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz" | tar xz -C "/usr/bin"
     cargo-binstall -y --locked "cargo-binutils@${CARGO_BINUTILS_VERSION}" \
                                "cargo-mutants@${CARGO_MUTANTS_VERSION}"
 

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -46,7 +46,7 @@ RUN --mount=type=bind,source=.devcontainer/rust/apt-requirements.json,target=/tm
         rustup target add thumbv7em-none-eabihf
     fi
 
-    wget -qO - "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz" | tar xz -C "/usr/bin"
+    wget --no-hsts --max-redirect=0 -qO - "https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz" | tar xz -C "/usr/bin"
     cargo-binstall -y --locked "cargo-binutils@${CARGO_BINUTILS_VERSION}" \
                                "cargo-mutants@${CARGO_MUTANTS_VERSION}"
 

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -21,6 +21,8 @@ ARG CARGO_BINSTALL_VERSION
 
 ADD --checksum=sha256:a753a83ea4c79a629790e003822d4e82bec5bf839120f1826969c2401bd9f559 \
   https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-gnu.tgz /cargo-binstall.tgz
+ADD --checksum=sha256:131d12bc7dd4d7c431b8f36447ce630c71e61975af1da6215c317bfde60e8a53 \
+  https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-gnu.tgz.sig /cargo-binstall.tgz.minisig
 
 # Downloader stage for ARM64 architecture
 FROM scratch AS downloader-arm64
@@ -29,6 +31,8 @@ ARG CARGO_BINSTALL_VERSION
 
 ADD --checksum=sha256:f70991d597655bc928444c0ac0dedcbd1d16a9e64d0b1ea544dde2cc710e25f6 \
   https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-aarch64-unknown-linux-gnu.tgz /cargo-binstall.tgz
+ADD --checksum=sha256:3d4ed28844baeeafa5e7df2112e623ae6098cf70b61983054d7ecd5cdbce35bb \
+  https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-aarch64-unknown-linux-gnu.tgz.sig /cargo-binstall.tgz.minisig
 
 # Select downloader stage based on target architecture.
 # Linters don't recognize the TARGETARCH variable, so we ignore warnings here.

--- a/.devcontainer/rust/Dockerfile
+++ b/.devcontainer/rust/Dockerfile
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+# hadolint global ignore=DL3006
 
 ARG BASE_IMAGE=ghcr.io/philips-software/amp-devcontainer-base:edge
 # Public minisign key for verifying ccache releases,
@@ -19,7 +20,7 @@ FROM scratch AS downloader-amd64
 ARG CARGO_BINSTALL_VERSION
 
 ADD --checksum=sha256:a753a83ea4c79a629790e003822d4e82bec5bf839120f1826969c2401bd9f559 \
-  https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz /cargo-binstall.tgz
+  https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-x86_64-unknown-linux-gnu.tgz /cargo-binstall.tgz
 
 # Downloader stage for ARM64 architecture
 FROM scratch AS downloader-arm64
@@ -27,7 +28,7 @@ FROM scratch AS downloader-arm64
 ARG CARGO_BINSTALL_VERSION
 
 ADD --checksum=sha256:f70991d597655bc928444c0ac0dedcbd1d16a9e64d0b1ea544dde2cc710e25f6 \
-  https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-$(uname -m)-unknown-linux-gnu.tgz /cargo-binstall.tgz
+  https://github.com/cargo-bins/cargo-binstall/releases/download/v${CARGO_BINSTALL_VERSION}/cargo-binstall-aarch64-unknown-linux-gnu.tgz /cargo-binstall.tgz
 
 # Select downloader stage based on target architecture.
 # Linters don't recognize the TARGETARCH variable, so we ignore warnings here.

--- a/.github/actions/container-size-diff/action.yml
+++ b/.github/actions/container-size-diff/action.yml
@@ -37,7 +37,7 @@ runs:
         cache-dependency-path: package.json
         node-version: 22.x
 
-    - run: npm install
+    - run: npm install --ignore-scripts
       shell: bash
 
     - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0

--- a/.github/workflows/wc-acceptance-test.yml
+++ b/.github/workflows/wc-acceptance-test.yml
@@ -68,7 +68,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24.8.0
-      - run: npm ci
+      - run: npm ci --ignore-scripts
       - run: npx playwright install --with-deps
       - name: Wait for Codespace to be active
         run: |

--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -270,7 +270,6 @@ jobs:
           ./diffoci diff --semantic --report-file=container-diff.json "${FROM_CONTAINER}" "${TO_CONTAINER}" || true
         env:
           DIFFOCI_SHA256: 01e6b50c1568c9d61c758ef6da81869f2c26c852698d73dca961b3617effe949
-        env:
           FROM_CONTAINER: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:edge
           TO_CONTAINER: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -264,7 +264,7 @@ jobs:
           CONTAINER: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}
       - run: |
           set -Eeuo pipefail
-          wget -O diffoci https://github.com/reproducible-containers/diffoci/releases/download/v0.1.7/diffoci-v0.1.7.linux-amd64
+          wget --max-redirect=0 -qO diffoci https://github.com/reproducible-containers/diffoci/releases/download/v0.1.8/diffoci-v0.1.8.linux-amd64
           chmod +x diffoci
           ./diffoci diff --semantic --report-file=container-diff.json "${FROM_CONTAINER}" "${TO_CONTAINER}" || true
         env:

--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -264,7 +264,7 @@ jobs:
           CONTAINER: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}
       - run: |
           set -Eeuo pipefail
-          wget --https-only -qO diffoci https://github.com/reproducible-containers/diffoci/releases/download/v0.1.8/diffoci-v0.1.8.linux-amd64
+          wget -qO diffoci https://github.com/reproducible-containers/diffoci/releases/download/v0.1.8/diffoci-v0.1.8.linux-amd64
           echo "${DIFFOCI_SHA256}  diffoci" | sha256sum --check --strict -
           chmod +x diffoci
           ./diffoci diff --semantic --report-file=container-diff.json "${FROM_CONTAINER}" "${TO_CONTAINER}" || true

--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -264,9 +264,12 @@ jobs:
           CONTAINER: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}
       - run: |
           set -Eeuo pipefail
-          wget --max-redirect=0 -qO diffoci https://github.com/reproducible-containers/diffoci/releases/download/v0.1.8/diffoci-v0.1.8.linux-amd64
+          wget --https-only -qO diffoci https://github.com/reproducible-containers/diffoci/releases/download/v0.1.8/diffoci-v0.1.8.linux-amd64
+          echo "${DIFFOCI_SHA256}  diffoci" | sha256sum --check --strict -
           chmod +x diffoci
           ./diffoci diff --semantic --report-file=container-diff.json "${FROM_CONTAINER}" "${TO_CONTAINER}" || true
+        env:
+          DIFFOCI_SHA256: 01e6b50c1568c9d61c758ef6da81869f2c26c852698d73dca961b3617effe949
         env:
           FROM_CONTAINER: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:edge
           TO_CONTAINER: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request updates the development container Dockerfiles for C++ and Rust to improve supply chain security, reproducibility, and consistency in dependency management. It also makes minor improvements to GitHub Actions workflows. The most important changes are grouped below.

**C++ Devcontainer Improvements:**

* Added explicit version pinning and checksum verification for `CPM.cmake` and `include-what-you-use` (IWYU) by downloading these dependencies in the Docker build and installing from local sources, rather than fetching at build time. This improves reproducibility and supply chain security. [[1]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R9-R10) [[2]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R47-R57) [[3]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7R98-R99) [[4]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L97-R110) [[5]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L159-R173) [[6]](diffhunk://#diff-7652813b143f0999fe3fb556854a6d9fc2e841e3f561615fcc5c12950959c2b7L192-R201)
* Improved installation steps for binaries (e.g., `ccache`, `xwin`) by using `install -m 0755` instead of `cp`, ensuring correct permissions.
* Updated `update-alternatives` commands to use quoted paths for improved safety.

**Rust Devcontainer Improvements:**

* Switched to downloading, verifying (with minisign), and installing a prebuilt `cargo-binstall` binary with checksum validation, instead of fetching and extracting directly from GitHub. This enhances supply chain security and reproducibility. [[1]](diffhunk://#diff-387900418d72acf92ef243e67df46b89a8f4e3d9ef4d4e26a6b93b605e5768edR2-R59) [[2]](diffhunk://#diff-387900418d72acf92ef243e67df46b89a8f4e3d9ef4d4e26a6b93b605e5768edL29-R83) [[3]](diffhunk://#diff-387900418d72acf92ef243e67df46b89a8f4e3d9ef4d4e26a6b93b605e5768edL49-R103) [[4]](diffhunk://#diff-387900418d72acf92ef243e67df46b89a8f4e3d9ef4d4e26a6b93b605e5768edL64-R118)
* Updated environment and path references to match the new installation location for `cargo-binstall`.
* Minor quoting improvements for variable usage.

**CI Workflow Improvements:**

* Updated `npm install` and `npm ci` commands in GitHub Actions to use `--ignore-scripts`, improving CI security by preventing arbitrary script execution during dependency installation. [[1]](diffhunk://#diff-bdc41c52c57375c8797849acbb6ab2806fcb2f0618126f54d610fc30ac0f6ff4L40-R40) [[2]](diffhunk://#diff-9f41086b486b4313058838f4af2c0cc2537e957a49b907f5b374c5ec45a9ac69L71-R71)
* Updated the `diffoci` tool to version 0.1.8 with checksum verification in the build workflow, improving security and reliability of image comparison.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
- [x] I understand the image size delta and agree the functionality justifies it
