### PR TITLE
refactor: reduce duplication in digest extraction

### DIFF
--- a/.github/actions/extract-manifest-digest/action.yml
+++ b/.github/actions/extract-manifest-digest/action.yml
@@ -1,0 +1,25 @@
+---
+name: 🔍 Extract Manifest Digest
+description: Inspect a container image manifest and extract its (index) digest.
+
+inputs:
+  container:
+    description: Fully qualified container image reference (including tag) to inspect.
+    required: true
+
+outputs:
+  digest:
+    description: The digest of the (multi-arch) image manifest.
+    value: ${{ steps.extract-digest.outputs.digest }}
+
+runs:
+  using: composite
+  steps:
+    - id: extract-digest
+      env:
+        CONTAINER: ${{ inputs.container }}
+      run: |
+        set -Eeuo pipefail
+        output=$(docker buildx imagetools inspect "${CONTAINER}" --format '{{json .}}')
+        echo "digest=$(echo "$output" | jq -r '.manifest.digest // .manifests[0].digest')" >> "$GITHUB_OUTPUT"
+      shell: bash

--- a/.github/actions/extract-manifest-digest/action.yml
+++ b/.github/actions/extract-manifest-digest/action.yml
@@ -20,6 +20,6 @@ runs:
         CONTAINER: ${{ inputs.container }}
       run: |
         set -Eeuo pipefail
-        output=$(docker buildx imagetools inspect "${CONTAINER}" --format '{{json .}}')
-        echo "digest=$(echo "$output" | jq -r '.manifest.digest // .manifests[0].digest')" >> "$GITHUB_OUTPUT"
+        digest="$(docker buildx imagetools inspect "${CONTAINER}" --format '{{json .}}' | jq -er '.manifest.digest // .manifests[0].digest')"
+        echo "digest=${digest}" >> "$GITHUB_OUTPUT"
       shell: bash

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -80,14 +80,10 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: audit
-      - name: Inspect manifest and extract digest
-        id: inspect-manifest
-        run: |
-          set -Eeuo pipefail
-          output=$(docker buildx imagetools inspect "${REGISTRY}/${GH_REPO}-${CONTAINER_FLAVOR}:${REF_NAME}" --format '{{json .}}')
-          echo "digest=$(echo "$output" | jq -r '.manifest.digest // .manifests[0].digest')" >> "$GITHUB_OUTPUT"
-        env:
-          GH_REPO: ${{ github.repository }}
+      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@refactor/extract-inspect-manifest-digest-action
+        id: extract-digest
+        with:
+          container: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}:${{ github.ref_name }}
       - name: Upload provenance to release
         run: |
           set -Eeuo pipefail
@@ -95,7 +91,7 @@ jobs:
           gh attestation verify --repo "${GH_REPO}" "oci://${REGISTRY}/${GH_REPO}-${CONTAINER_FLAVOR}@${DIGEST}" --format json --jq '.[] | .attestation.bundle.dsseEnvelope | select(.payloadType == "application/vnd.in-toto+json").payload' | base64 -d | jq . > "${REPOSITORY_OWNER}-${REPOSITORY_NAME}-${CONTAINER_FLAVOR}_${FORMATTED_DIGEST}.intoto.jsonl"
           gh release upload --clobber "${REF_NAME}" ./*.intoto.jsonl
         env:
-          DIGEST: ${{ steps.inspect-manifest.outputs.digest }}
+          DIGEST: ${{ steps.extract-digest.outputs.digest }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}
@@ -114,7 +110,7 @@ jobs:
           UPDATED_NOTES=${UPDATED_NOTES//"{{ amp-devcontainer-${CONTAINER_FLAVOR}-tools }}"/"${TOOLS_TABLE}"}
           gh release edit "${REF_NAME}" --notes "${UPDATED_NOTES}"
         env:
-          DIGEST: ${{ steps.inspect-manifest.outputs.digest }}
+          DIGEST: ${{ steps.extract-digest.outputs.digest }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
       - name: Upload tool inventory to release
@@ -125,7 +121,7 @@ jobs:
           cp tool-inventory/tool-inventory.json "${INVENTORY}"
           gh release upload --clobber "${REF_NAME}" "${INVENTORY}"
         env:
-          DIGEST: ${{ steps.inspect-manifest.outputs.digest }}
+          DIGEST: ${{ steps.extract-digest.outputs.digest }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY_OWNER: ${{ github.repository_owner }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: audit
-      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@refactor/extract-inspect-manifest-digest-action
+      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@524d96e6086501fc3373250d58d5eac002c69429
         id: extract-digest
         with:
           container: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}:${{ github.ref_name }}

--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -242,7 +242,7 @@ jobs:
           METADATA_JSON: ${{ steps.metadata.outputs.json }}
         shell: bash
         working-directory: ${{ runner.temp }}/digests
-      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@refactor/extract-inspect-manifest-digest-action
+      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@524d96e6086501fc3373250d58d5eac002c69429
         id: extract-digest
         with:
           container: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}

--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -188,7 +188,7 @@ jobs:
       packages: write # is needed to push image manifest when using GitHub Container Registry
       pull-requests: write # is needed by marocchino/sticky-pull-request-comment to post comments
     outputs:
-      digest: ${{ steps.inspect-manifest.outputs.digest }}
+      digest: ${{ steps.extract-digest.outputs.digest }}
       version: ${{ steps.metadata.outputs.version }}
     steps:
       - uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -242,14 +242,10 @@ jobs:
           METADATA_JSON: ${{ steps.metadata.outputs.json }}
         shell: bash
         working-directory: ${{ runner.temp }}/digests
-      - name: Inspect manifest and extract digest
-        id: inspect-manifest
-        run: |
-          set -Eeuo pipefail
-          output=$(docker buildx imagetools inspect "${CONTAINER}" --format '{{json .}}')
-          echo "digest=$(echo "$output" | jq -r '.manifest.digest // .manifests[0].digest')" >> "$GITHUB_OUTPUT"
-        env:
-          CONTAINER: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}
+      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@refactor/extract-inspect-manifest-digest-action
+        id: extract-digest
+        with:
+          container: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}
       - run: |
           set -Eeuo pipefail
           wget -qO diffoci https://github.com/reproducible-containers/diffoci/releases/download/v0.1.8/diffoci-v0.1.8.linux-amd64
@@ -277,7 +273,7 @@ jobs:
             ${{ steps.container-size-diff.outputs.size-diff-markdown }}
       - uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
         with:
-          image: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}@${{ steps.inspect-manifest.outputs.digest }}
+          image: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}@${{ steps.extract-digest.outputs.digest }}
           registry-username: ${{ secrets.DOCKER_REGISTRY_USERNAME || github.actor }}
           registry-password: ${{ secrets.DOCKER_REGISTRY_PASSWORD || github.token }}
           dependency-snapshot: true
@@ -306,14 +302,14 @@ jobs:
       - uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
         with:
           subject-name: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}
-          subject-digest: ${{ steps.inspect-manifest.outputs.digest }}
+          subject-digest: ${{ steps.extract-digest.outputs.digest }}
           show-summary: false
           push-to-registry: true
       # @sbdl test-sec-0001 is test { custom:title is "Verify attestation"; requirement is req-sec-0002 }
       - name: Verify attestation
         run: gh attestation verify --repo "${GH_REPO}" --signer-workflow philips-software/amp-devcontainer/.github/workflows/wc-build-push.yml "oci://${FULLY_QUALIFIED_IMAGE_NAME}@${DIGEST}"
         env:
-          DIGEST: ${{ steps.inspect-manifest.outputs.digest }}
+          DIGEST: ${{ steps.extract-digest.outputs.digest }}
           FULLY_QUALIFIED_IMAGE_NAME: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This pull request refactors the process for extracting a container image manifest digest in the GitHub Actions workflows. The main improvement is the introduction of a reusable composite action, `extract-manifest-digest`, which replaces duplicated inline shell scripts across workflows. This change improves maintainability and consistency in how digests are extracted and referenced.

**Workflow Refactoring and Reusability:**

* Added a new composite action `.github/actions/extract-manifest-digest/action.yml` that encapsulates the logic for extracting the manifest digest from a container image using `docker buildx imagetools` and `jq`.
* Updated both `.github/workflows/release-build.yml` and `.github/workflows/wc-build-push.yml` to use the new `extract-manifest-digest` action instead of duplicating the shell script, simplifying workflow steps and reducing maintenance overhead. [[1]](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fL83-R94) [[2]](diffhunk://#diff-2a36c16587df302d628f7fa10f67cd05731fd199924c74e067618126cf8e7d8cL245-R248)

**Workflow Variable Consistency:**

* Replaced all references to the old step ID (`inspect-manifest`) with the new step ID (`extract-digest`) for digest outputs in subsequent workflow steps, ensuring consistency and correctness. [[1]](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fL117-R113) [[2]](diffhunk://#diff-52120b4145bd2cf9c735193f6a093a7944688b21f04e854447e34a5049fc829fL128-R124) [[3]](diffhunk://#diff-2a36c16587df302d628f7fa10f67cd05731fd199924c74e067618126cf8e7d8cL191-R191) [[4]](diffhunk://#diff-2a36c16587df302d628f7fa10f67cd05731fd199924c74e067618126cf8e7d8cL280-R276) [[5]](diffhunk://#diff-2a36c16587df302d628f7fa10f67cd05731fd199924c74e067618126cf8e7d8cL309-R312)

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [ ] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [ ] I have added tests for new behavior, and have not broken any existing tests
- [ ] I have added or updated relevant documentation
- [ ] I have verified that all added components are accounted for in the SBOM
- [ ] I understand the image size delta and agree the functionality justifies it
