### PR TITLE
ci: use released actions

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -15,7 +15,7 @@ permissions: {}
 jobs:
   build-push-test:
     name: Build → Push → Test
-    if: ${{ !startsWith(github.ref_name, 'actions-') }}
+    if: ${{ !startsWith(github.ref_name, 'actions/') }}
     uses: ./.github/workflows/build-push-test.yml
     permissions:
       actions: read # is needed by anchore/sbom-action to find workflow artifacts when attaching release assets
@@ -33,7 +33,7 @@ jobs:
 
   apply-release-notes-template:
     name: 📝 Apply Release Template
-    if: ${{ !startsWith(github.ref_name, 'actions-') }}
+    if: ${{ !startsWith(github.ref_name, 'actions/') }}
     runs-on: ubuntu-latest
     permissions:
       # Please note that this is an overly broad scope, but GitHub does not
@@ -80,7 +80,7 @@ jobs:
         with:
           disable-sudo: true
           egress-policy: audit
-      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@524d96e6086501fc3373250d58d5eac002c69429
+      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@eccf76dc2da974d3e49531784bf4df2d0e8bbbaa # actions/v1.2.0
         id: extract-digest
         with:
           container: ${{ env.REGISTRY }}/${{ github.repository }}-${{ matrix.flavor }}:${{ github.ref_name }}
@@ -129,14 +129,14 @@ jobs:
 
   publish-devcontainer-templates:
     name: 📝 Publish templates
-    if: ${{ !startsWith(github.ref_name, 'actions-') }}
+    if: ${{ !startsWith(github.ref_name, 'actions/') }}
     uses: ./.github/workflows/wc-publish-templates.yml
     permissions:
       packages: write # is needed by devcontainers/action to write templates as OCI artifacts
 
   generate-documents:
     name: 📄 Documentation
-    if: ${{ !startsWith(github.ref_name, 'actions-') }}
+    if: ${{ !startsWith(github.ref_name, 'actions/') }}
     uses: ./.github/workflows/wc-document-generation.yml
     with:
       is-release: true
@@ -170,7 +170,7 @@ jobs:
 
   comment-released-prs:
     name: Comment on released PRs
-    if: ${{ !startsWith(github.ref_name, 'actions-') }}
+    if: ${{ !startsWith(github.ref_name, 'actions/') }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # is needed by rdlf0/comment-released-prs-action to post comments on PRs

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: philips-software/amp-devcontainer/.github/actions/update-apt-packages@370c48c32a438aafb841c2b1f9f442f21919c2a9 # actions/v1.1.0
+      - uses: philips-software/amp-devcontainer/.github/actions/update-apt-packages@eccf76dc2da974d3e49531784bf4df2d0e8bbbaa # actions/v1.2.0
         id: update-packages
         with:
           input-file: .devcontainer/${{ matrix.flavor }}/apt-requirements*.json
@@ -63,9 +63,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      # TODO: revert to a pinned philips-software/amp-devcontainer/.github/actions/update-vscode-extensions@<sha> # actions/vX.Y.Z once this PR's action changes are released
       # continue-on-error is intentional: a single bad file shouldn't block a PR for the rest; see the trailing "Fail if..." step
-      - uses: ./.github/actions/update-vscode-extensions
+      - uses: philips-software/amp-devcontainer/.github/actions/update-vscode-extensions@eccf76dc2da974d3e49531784bf4df2d0e8bbbaa # actions/v1.2.0
         id: update-extensions
         continue-on-error: true
         with:

--- a/.github/workflows/wc-build-push.yml
+++ b/.github/workflows/wc-build-push.yml
@@ -263,7 +263,7 @@ jobs:
           METADATA_JSON: ${{ steps.metadata.outputs.json }}
         shell: bash
         working-directory: ${{ runner.temp }}/digests
-      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@524d96e6086501fc3373250d58d5eac002c69429
+      - uses: philips-software/amp-devcontainer/.github/actions/extract-manifest-digest@eccf76dc2da974d3e49531784bf4df2d0e8bbbaa # actions/v1.2.0
         id: extract-digest
         with:
           container: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:${{ steps.metadata.outputs.version }}
@@ -282,7 +282,7 @@ jobs:
           name: container-diff-${{ needs.sanitize-image-name.outputs.image-basename }}
           path: container-diff.json
           retention-days: 10
-      - uses: philips-software/amp-devcontainer/.github/actions/container-size-diff@370c48c32a438aafb841c2b1f9f442f21919c2a9 # actions/v1.1.0
+      - uses: philips-software/amp-devcontainer/.github/actions/container-size-diff@eccf76dc2da974d3e49531784bf4df2d0e8bbbaa # actions/v1.2.0
         id: container-size-diff
         with:
           from-container: ${{ needs.sanitize-image-name.outputs.fully-qualified-image-name }}:edge


### PR DESCRIPTION
# :rocket: Hey, I have created a Pull Request

## Description of changes

This PR updates all action uses to a released version. And a small issue is fixed related to release notes generation. The templates should only be applied for the container release, not for the actions.

## :heavy_check_mark: Checklist

<!-- We follow conventional commit-style PR titles and kebab-case branch names -->

- [x] I have followed the [contribution guidelines](https://github.com/philips-software/amp-devcontainer/blob/main/.github/CONTRIBUTING.md) for this repository
- [x] I have added tests for new behavior, and have not broken any existing tests
- [x] I have added or updated relevant documentation
- [x] I have verified that all added components are accounted for in the SBOM
- [x] I understand the image size delta and agree the functionality justifies it
